### PR TITLE
지원자 면접 질문 평가와 합격자 명단 관련 기능 구현

### DIFF
--- a/src/main/java/com/gotcha/server/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/gotcha/server/applicant/controller/ApplicantController.java
@@ -4,6 +4,7 @@ import com.gotcha.server.applicant.dto.request.InterviewProceedRequest;
 import com.gotcha.server.applicant.dto.response.ApplicantResponse;
 import com.gotcha.server.applicant.dto.response.ApplicantsResponse;
 import com.gotcha.server.applicant.dto.response.InterviewProceedResponse;
+import com.gotcha.server.applicant.dto.response.PassedApplicantsResponse;
 import com.gotcha.server.applicant.dto.response.TodayInterviewResponse;
 import com.gotcha.server.applicant.service.ApplicantService;
 import com.gotcha.server.auth.security.MemberDetails;
@@ -42,5 +43,10 @@ public class ApplicantController {
     @GetMapping("/{applicant-id}")
     public ResponseEntity<ApplicantResponse> findApplicantDetailsById(@PathVariable(name = "applicant-id") Long applicantId) {
         return ResponseEntity.ok(applicantService.findApplicantDetailsById(applicantId));
+    }
+
+    @GetMapping("/pass")
+    public ResponseEntity<List<PassedApplicantsResponse>> findAllPassedApplicantsByInterview(@RequestParam(name = "interview-id") Long interviewId) {
+        return ResponseEntity.ok(applicantService.listPassedApplicantsByInterview(interviewId));
     }
 }

--- a/src/main/java/com/gotcha/server/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/gotcha/server/applicant/controller/ApplicantController.java
@@ -1,6 +1,7 @@
 package com.gotcha.server.applicant.controller;
 
 import com.gotcha.server.applicant.dto.request.InterviewProceedRequest;
+import com.gotcha.server.applicant.dto.request.PassEmailSendRequest;
 import com.gotcha.server.applicant.dto.response.ApplicantResponse;
 import com.gotcha.server.applicant.dto.response.ApplicantsResponse;
 import com.gotcha.server.applicant.dto.response.InterviewProceedResponse;
@@ -36,17 +37,23 @@ public class ApplicantController {
     }
 
     @GetMapping("")
-    public ResponseEntity<List<ApplicantsResponse>> findAllApplicantByInterview(@RequestParam(name = "interview-id") Long interviewId) {
+    public ResponseEntity<List<ApplicantsResponse>> findAllApplicantByInterview(@RequestParam(name = "interview-id") final Long interviewId) {
         return ResponseEntity.ok(applicantService.listApplicantsByInterview(interviewId));
     }
 
     @GetMapping("/{applicant-id}")
-    public ResponseEntity<ApplicantResponse> findApplicantDetailsById(@PathVariable(name = "applicant-id") Long applicantId) {
+    public ResponseEntity<ApplicantResponse> findApplicantDetailsById(@PathVariable(name = "applicant-id") final Long applicantId) {
         return ResponseEntity.ok(applicantService.findApplicantDetailsById(applicantId));
     }
 
     @GetMapping("/pass")
-    public ResponseEntity<List<PassedApplicantsResponse>> findAllPassedApplicantsByInterview(@RequestParam(name = "interview-id") Long interviewId) {
+    public ResponseEntity<List<PassedApplicantsResponse>> findAllPassedApplicantsByInterview(@RequestParam(name = "interview-id") final Long interviewId) {
         return ResponseEntity.ok(applicantService.listPassedApplicantsByInterview(interviewId));
+    }
+
+    @PostMapping("/send-email")
+    public ResponseEntity<Void> sendPassEmail(@RequestBody final PassEmailSendRequest request) {
+        applicantService.sendPassEmail(request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/gotcha/server/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/gotcha/server/applicant/controller/ApplicantController.java
@@ -41,6 +41,6 @@ public class ApplicantController {
 
     @GetMapping("/{applicant-id}")
     public ResponseEntity<ApplicantResponse> findApplicantDetailsById(@PathVariable(name = "applicant-id") Long applicantId) {
-        return ResponseEntity.ok(applicantService.findApplicantById(applicantId));
+        return ResponseEntity.ok(applicantService.findApplicantDetailsById(applicantId));
     }
 }

--- a/src/main/java/com/gotcha/server/applicant/domain/Applicant.java
+++ b/src/main/java/com/gotcha/server/applicant/domain/Applicant.java
@@ -3,6 +3,7 @@ package com.gotcha.server.applicant.domain;
 import com.gotcha.server.project.domain.Interview;
 import com.gotcha.server.question.domain.IndividualQuestion;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -36,6 +37,12 @@ public class Applicant {
     @OneToMany(mappedBy = "applicant", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<IndividualQuestion> questions = new ArrayList<>();
 
+    @Column(nullable = false)
+    private Outcome outcome;
+
+    @Column(nullable = false)
+    private InterviewStatus interviewStatus;
+
     private LocalDate date;
     private String name;
     private Integer age;
@@ -44,8 +51,7 @@ public class Applicant {
     private String position;
     private String path;
     private Integer totalScore;
-    private Outcome outcome;
-    private InterviewStatus interviewStatus;
+    private int ranking;
     private String resumeLink;
     private String portfolio;
 
@@ -53,10 +59,15 @@ public class Applicant {
         this.interview = interview;
         this.outcome = Outcome.PENDING;
         this.interviewStatus = InterviewStatus.PREPARATION;
+        this.ranking = 0;
     }
 
     public void moveToNextStatus() {
         interviewStatus = interviewStatus.moveToNextStatus();
+    }
+
+    public void determineOutcome(Outcome outcome) {
+        this.outcome = outcome;
     }
 
     public void addInterviewer(final Interviewer interviewer) {

--- a/src/main/java/com/gotcha/server/applicant/domain/Applicant.java
+++ b/src/main/java/com/gotcha/server/applicant/domain/Applicant.java
@@ -43,6 +43,9 @@ public class Applicant {
     @Column(nullable = false)
     private InterviewStatus interviewStatus;
 
+    @Column(nullable = false)
+    private String email;
+
     private LocalDate date;
     private String name;
     private Integer age;

--- a/src/main/java/com/gotcha/server/applicant/domain/Outcome.java
+++ b/src/main/java/com/gotcha/server/applicant/domain/Outcome.java
@@ -1,7 +1,21 @@
 package com.gotcha.server.applicant.domain;
 
 public enum Outcome {
-    PENDING,
-    PASS,
-    FAIL;
+    PENDING(""),
+    PASS("합격하신 것을 축하드립니다.\n담당자가 빠른 시일 내 개별적으로 연락을 드릴 예정입니다.\n"),
+    FAIL("아쉽게도 불합격하셨습니다.\n");
+
+    String message;
+
+    Outcome(final String message) {
+        this.message = message;
+    }
+
+    public String createPassEmailMessage(
+            final String name, final String project, final String interview, final String position) {
+        return String.format("안녕하세요. %s님.\n", name)
+                + String.format("귀하께서 지원하신 %s %s %s 전형에 ", project, interview, position)
+                + this.message
+                + String.format("이번 %s %s %s 전형에 대한 관심과 지원 감사합니다.", project, interview, position);
+    }
 }

--- a/src/main/java/com/gotcha/server/applicant/dto/request/PassEmailSendRequest.java
+++ b/src/main/java/com/gotcha/server/applicant/dto/request/PassEmailSendRequest.java
@@ -1,0 +1,5 @@
+package com.gotcha.server.applicant.dto.request;
+
+public record PassEmailSendRequest(Long interviewId) {
+
+}

--- a/src/main/java/com/gotcha/server/applicant/dto/response/ApplicantsResponse.java
+++ b/src/main/java/com/gotcha/server/applicant/dto/response/ApplicantsResponse.java
@@ -19,7 +19,7 @@ public class ApplicantsResponse {
     private String name;
     private InterviewStatus status;
     private LocalDate date;
-    private List<String> interviewerProfiles;
+    private List<String> interviewerEmails;
     private Integer questionCount;
     private List<KeywordResponse> keywords;
 
@@ -30,8 +30,8 @@ public class ApplicantsResponse {
                         .name(a.getName())
                         .status(a.getInterviewStatus())
                         .date(a.getDate())
-                        .interviewerProfiles(a.getInterviewers().stream()
-                                .map(interviewer -> interviewer.getMember().getProfileUrl())
+                        .interviewerEmails(a.getInterviewers().stream()
+                                .map(interviewer -> interviewer.getMember().getEmail())
                                 .toList())
                         .questionCount(a.getQuestions().size())
                         .keywords(keywordMap.get(a))

--- a/src/main/java/com/gotcha/server/applicant/dto/response/PassedApplicantsResponse.java
+++ b/src/main/java/com/gotcha/server/applicant/dto/response/PassedApplicantsResponse.java
@@ -1,0 +1,33 @@
+package com.gotcha.server.applicant.dto.response;
+
+import com.gotcha.server.applicant.domain.Applicant;
+import java.util.List;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PassedApplicantsResponse {
+    private Long id;
+    private String name;
+    private Integer score;
+    private Integer rank;
+    private List<String> keywords;
+
+    public static List<PassedApplicantsResponse> generateList(List<Applicant> applicants, Map<Applicant, List<String>> keywords) {
+        return applicants.stream()
+                .map(a -> PassedApplicantsResponse.builder()
+                        .id(a.getId())
+                        .name(a.getName())
+                        .score(a.getTotalScore())
+                        .rank(a.getRanking())
+                        .keywords(keywords.get(a))
+                        .build())
+                .toList();
+    }
+}

--- a/src/main/java/com/gotcha/server/applicant/repository/ApplicantDslRepository.java
+++ b/src/main/java/com/gotcha/server/applicant/repository/ApplicantDslRepository.java
@@ -1,9 +1,11 @@
 package com.gotcha.server.applicant.repository;
 
 import com.gotcha.server.applicant.dto.response.ApplicantsResponse;
+import com.gotcha.server.applicant.dto.response.PassedApplicantsResponse;
 import com.gotcha.server.project.domain.Interview;
 import java.util.List;
 
 public interface ApplicantDslRepository {
     List<ApplicantsResponse> findAllByInterviewWithKeywords(Interview interview);
+    List<PassedApplicantsResponse> findAllPassedApplicantsWithKeywords(Interview interview);
 }

--- a/src/main/java/com/gotcha/server/applicant/repository/ApplicantRepository.java
+++ b/src/main/java/com/gotcha/server/applicant/repository/ApplicantRepository.java
@@ -11,5 +11,5 @@ public interface ApplicantRepository extends JpaRepository<Applicant, Long>, App
             + "join fetch a.interviewers i "
             + "join fetch i.member "
             + "where a.id = :applicantId")
-    Optional<Applicant> findById(@Param("applicantId") Long id);
+    Optional<Applicant> findByIdWithInterviewer(@Param("applicantId") Long id);
 }

--- a/src/main/java/com/gotcha/server/applicant/repository/ApplicantRepository.java
+++ b/src/main/java/com/gotcha/server/applicant/repository/ApplicantRepository.java
@@ -1,6 +1,8 @@
 package com.gotcha.server.applicant.repository;
 
 import com.gotcha.server.applicant.domain.Applicant;
+import com.gotcha.server.project.domain.Interview;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -12,4 +14,6 @@ public interface ApplicantRepository extends JpaRepository<Applicant, Long>, App
             + "join fetch i.member "
             + "where a.id = :applicantId")
     Optional<Applicant> findByIdWithInterviewer(@Param("applicantId") Long id);
+
+    List<Applicant> findAllByInterview(Interview interview);
 }

--- a/src/main/java/com/gotcha/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/gotcha/server/applicant/service/ApplicantService.java
@@ -8,6 +8,7 @@ import com.gotcha.server.applicant.dto.request.InterviewProceedRequest;
 import com.gotcha.server.applicant.dto.response.ApplicantResponse;
 import com.gotcha.server.applicant.dto.response.ApplicantsResponse;
 import com.gotcha.server.applicant.dto.response.InterviewProceedResponse;
+import com.gotcha.server.applicant.dto.response.PassedApplicantsResponse;
 import com.gotcha.server.applicant.dto.response.TodayInterviewResponse;
 import com.gotcha.server.applicant.repository.ApplicantRepository;
 import com.gotcha.server.applicant.repository.InterviewerRepository;
@@ -72,5 +73,11 @@ public class ApplicantService {
                 .orElseThrow(() -> new AppException(ErrorCode.APPLICANT_NOT_FOUNT));
         List<Keyword> keywords = keywordRepository.findAllByApplicant(applicant);
         return ApplicantResponse.from(applicant, keywords);
+    }
+
+    public List<PassedApplicantsResponse> listPassedApplicantsByInterview(final Long interviewId) {
+        Interview interview = interviewRepository.findById(interviewId)
+                .orElseThrow(() -> new AppException(ErrorCode.INTERVIEW_NOT_FOUNT));
+        return applicantRepository.findAllPassedApplicantsWithKeywords(interview);
     }
 }

--- a/src/main/java/com/gotcha/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/gotcha/server/applicant/service/ApplicantService.java
@@ -67,8 +67,8 @@ public class ApplicantService {
         return applicantRepository.findAllByInterviewWithKeywords(interview);
     }
 
-    public ApplicantResponse findApplicantById(final Long applicantId) {
-        Applicant applicant = applicantRepository.findById(applicantId)
+    public ApplicantResponse findApplicantDetailsById(final Long applicantId) {
+        Applicant applicant = applicantRepository.findByIdWithInterviewer(applicantId)
                 .orElseThrow(() -> new AppException(ErrorCode.APPLICANT_NOT_FOUNT));
         List<Keyword> keywords = keywordRepository.findAllByApplicant(applicant);
         return ApplicantResponse.from(applicant, keywords);

--- a/src/main/java/com/gotcha/server/evaluation/controller/EvaluationController.java
+++ b/src/main/java/com/gotcha/server/evaluation/controller/EvaluationController.java
@@ -3,14 +3,18 @@ package com.gotcha.server.evaluation.controller;
 import com.gotcha.server.auth.security.MemberDetails;
 import com.gotcha.server.evaluation.dto.request.EvaluateRequest;
 import com.gotcha.server.evaluation.dto.request.OneLinerRequest;
+import com.gotcha.server.evaluation.dto.response.QuestionEvaluationResponse;
 import com.gotcha.server.evaluation.service.EvaluationService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController("/api/evaluations")
@@ -28,5 +32,10 @@ public class EvaluationController {
     public ResponseEntity<Void> createOneLiner(@AuthenticationPrincipal final MemberDetails details, @RequestBody final OneLinerRequest request) {
         evaluationService.createOneLiner(details, request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping("/questions")
+    public ResponseEntity<QuestionEvaluationResponse> findEvaluationsByQuestion(@RequestParam(value = "question-id", required = false) Long questionId) {
+        return ResponseEntity.ok(evaluationService.findQuestionEvaluations(questionId));
     }
 }

--- a/src/main/java/com/gotcha/server/evaluation/controller/EvaluationController.java
+++ b/src/main/java/com/gotcha/server/evaluation/controller/EvaluationController.java
@@ -4,6 +4,7 @@ import com.gotcha.server.auth.security.MemberDetails;
 import com.gotcha.server.evaluation.dto.request.EvaluateRequest;
 import com.gotcha.server.evaluation.dto.request.OneLinerRequest;
 import com.gotcha.server.evaluation.dto.response.QuestionEvaluationResponse;
+import com.gotcha.server.evaluation.dto.response.QuestionRankResponse;
 import com.gotcha.server.evaluation.service.EvaluationService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -35,7 +36,12 @@ public class EvaluationController {
     }
 
     @GetMapping("/questions")
-    public ResponseEntity<QuestionEvaluationResponse> findEvaluationsByQuestion(@RequestParam(value = "question-id", required = false) Long questionId) {
+    public ResponseEntity<QuestionEvaluationResponse> findEvaluationsByQuestion(@RequestParam(value = "question-id") Long questionId) {
         return ResponseEntity.ok(evaluationService.findQuestionEvaluations(questionId));
+    }
+
+    @GetMapping("/questions-rank")
+    public ResponseEntity<List<QuestionRankResponse>> findQuestionRanksByApplicant(@RequestParam(value = "applicant-id") Long applicantId) {
+        return ResponseEntity.ok(evaluationService.findQuestionRanks(applicantId));
     }
 }

--- a/src/main/java/com/gotcha/server/evaluation/domain/Evaluation.java
+++ b/src/main/java/com/gotcha/server/evaluation/domain/Evaluation.java
@@ -39,4 +39,8 @@ public class Evaluation extends BaseTimeEntity {
         this.question = question;
         this.interviewer = interviewer;
     }
+
+    public void setQuestion(final IndividualQuestion question) {
+        this.question = question;
+    }
 }

--- a/src/main/java/com/gotcha/server/evaluation/domain/QuestionEvaluations.java
+++ b/src/main/java/com/gotcha/server/evaluation/domain/QuestionEvaluations.java
@@ -1,4 +1,4 @@
-package com.gotcha.server.evaluation.service;
+package com.gotcha.server.evaluation.domain;
 
 import com.gotcha.server.evaluation.dto.response.QuestionRankResponse;
 import com.gotcha.server.question.domain.IndividualQuestion;

--- a/src/main/java/com/gotcha/server/evaluation/dto/response/EvaluationResponse.java
+++ b/src/main/java/com/gotcha/server/evaluation/dto/response/EvaluationResponse.java
@@ -1,0 +1,5 @@
+package com.gotcha.server.evaluation.dto.response;
+
+public record EvaluationResponse(Integer score, String content) {
+
+}

--- a/src/main/java/com/gotcha/server/evaluation/dto/response/QuestionEvaluationResponse.java
+++ b/src/main/java/com/gotcha/server/evaluation/dto/response/QuestionEvaluationResponse.java
@@ -1,0 +1,6 @@
+package com.gotcha.server.evaluation.dto.response;
+
+import java.util.List;
+
+public record QuestionEvaluationResponse(String question, boolean isCommon, List<EvaluationResponse> evaluations) {
+}

--- a/src/main/java/com/gotcha/server/evaluation/dto/response/QuestionRankResponse.java
+++ b/src/main/java/com/gotcha/server/evaluation/dto/response/QuestionRankResponse.java
@@ -1,0 +1,5 @@
+package com.gotcha.server.evaluation.dto.response;
+
+public record QuestionRankResponse(Long id, Integer totalScore) {
+
+}

--- a/src/main/java/com/gotcha/server/evaluation/dto/response/QuestionRankResponse.java
+++ b/src/main/java/com/gotcha/server/evaluation/dto/response/QuestionRankResponse.java
@@ -1,5 +1,5 @@
 package com.gotcha.server.evaluation.dto.response;
 
-public record QuestionRankResponse(Long id, Integer totalScore) {
+public record QuestionRankResponse(Long id, Double totalScore) {
 
 }

--- a/src/main/java/com/gotcha/server/evaluation/repository/EvaluationRepository.java
+++ b/src/main/java/com/gotcha/server/evaluation/repository/EvaluationRepository.java
@@ -1,9 +1,10 @@
 package com.gotcha.server.evaluation.repository;
 
 import com.gotcha.server.evaluation.domain.Evaluation;
+import com.gotcha.server.question.domain.IndividualQuestion;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface EvaluationRepository extends JpaRepository<Evaluation, Long> {
+    List<Evaluation> findAllByQuestion(IndividualQuestion question);
 }

--- a/src/main/java/com/gotcha/server/evaluation/service/EvaluationService.java
+++ b/src/main/java/com/gotcha/server/evaluation/service/EvaluationService.java
@@ -7,6 +7,7 @@ import com.gotcha.server.applicant.repository.InterviewerRepository;
 import com.gotcha.server.auth.security.MemberDetails;
 import com.gotcha.server.evaluation.domain.Evaluation;
 import com.gotcha.server.evaluation.domain.OneLiner;
+import com.gotcha.server.evaluation.domain.QuestionEvaluations;
 import com.gotcha.server.evaluation.dto.request.EvaluateRequest;
 import com.gotcha.server.evaluation.dto.request.OneLinerRequest;
 import com.gotcha.server.evaluation.dto.response.EvaluationResponse;

--- a/src/main/java/com/gotcha/server/evaluation/service/EvaluationService.java
+++ b/src/main/java/com/gotcha/server/evaluation/service/EvaluationService.java
@@ -40,12 +40,7 @@ public class EvaluationService {
         Interviewer interviewer = interviewerRepository.findByMember(details.member())
                 .orElseThrow(() -> new AppException(ErrorCode.UNAUTHORIZED_INTERVIEWER));
 
-        List<Long> questionIds = requests.stream().map(EvaluateRequest::questionId).toList();
-        List<IndividualQuestion> questions = individualQuestionRepository.findAllByIdIn(questionIds);
-        if(questions.size() != questionIds.size()) {
-            throw new AppException(ErrorCode.QUESTION_NOT_FOUNT);
-        }
-
+        List<IndividualQuestion> questions = getQuestionsBeingEvaluated(requests);
         Map<Long, IndividualQuestion> questionMap = questions.stream().collect(Collectors.toMap(IndividualQuestion::getId, q->q));
         List<Evaluation> evaluations = requests.stream()
                 .map(request -> Evaluation.builder()
@@ -56,6 +51,15 @@ public class EvaluationService {
                         .build())
                 .toList();
         evaluationRepository.saveAll(evaluations);
+    }
+
+    private List<IndividualQuestion> getQuestionsBeingEvaluated(final List<EvaluateRequest> requests) {
+        List<Long> questionIds = requests.stream().map(EvaluateRequest::questionId).toList();
+        List<IndividualQuestion> questions = individualQuestionRepository.findAllByIdIn(questionIds);
+        if(questions.size() != questionIds.size()) {
+            throw new AppException(ErrorCode.QUESTION_NOT_FOUNT);
+        }
+        return questions;
     }
 
     @Transactional

--- a/src/main/java/com/gotcha/server/evaluation/service/EvaluationService.java
+++ b/src/main/java/com/gotcha/server/evaluation/service/EvaluationService.java
@@ -11,6 +11,7 @@ import com.gotcha.server.evaluation.dto.request.EvaluateRequest;
 import com.gotcha.server.evaluation.dto.request.OneLinerRequest;
 import com.gotcha.server.evaluation.dto.response.EvaluationResponse;
 import com.gotcha.server.evaluation.dto.response.QuestionEvaluationResponse;
+import com.gotcha.server.evaluation.dto.response.QuestionRankResponse;
 import com.gotcha.server.evaluation.repository.EvaluationRepository;
 import com.gotcha.server.evaluation.repository.OneLinerRepository;
 import com.gotcha.server.global.exception.AppException;
@@ -73,5 +74,14 @@ public class EvaluationService {
                 .map(e -> new EvaluationResponse(e.getScore(), e.getContent()))
                 .toList();
         return new QuestionEvaluationResponse(question.getContent(), question.isCommon(), evaluations);
+    }
+
+    public List<QuestionRankResponse> findQuestionRanks(final Long applicantId) {
+        Applicant applicant = applicantRepository.findById(applicantId)
+                .orElseThrow(() -> new AppException(ErrorCode.APPLICANT_NOT_FOUNT));
+
+        List<IndividualQuestion> questions = individualQuestionRepository.findAllDuringInterview(applicant);
+        QuestionEvaluations evaluations = new QuestionEvaluations(questions);
+        return evaluations.createQuestionRanks();
     }
 }

--- a/src/main/java/com/gotcha/server/evaluation/service/EvaluationService.java
+++ b/src/main/java/com/gotcha/server/evaluation/service/EvaluationService.java
@@ -84,7 +84,7 @@ public class EvaluationService {
         Applicant applicant = applicantRepository.findById(applicantId)
                 .orElseThrow(() -> new AppException(ErrorCode.APPLICANT_NOT_FOUNT));
 
-        List<IndividualQuestion> questions = individualQuestionRepository.findAllDuringInterview(applicant);
+        List<IndividualQuestion> questions = individualQuestionRepository.findAllAfterEvaluation(applicant);
         QuestionEvaluations evaluations = new QuestionEvaluations(questions);
         return evaluations.createQuestionRanks();
     }

--- a/src/main/java/com/gotcha/server/evaluation/service/EvaluationService.java
+++ b/src/main/java/com/gotcha/server/evaluation/service/EvaluationService.java
@@ -9,6 +9,8 @@ import com.gotcha.server.evaluation.domain.Evaluation;
 import com.gotcha.server.evaluation.domain.OneLiner;
 import com.gotcha.server.evaluation.dto.request.EvaluateRequest;
 import com.gotcha.server.evaluation.dto.request.OneLinerRequest;
+import com.gotcha.server.evaluation.dto.response.EvaluationResponse;
+import com.gotcha.server.evaluation.dto.response.QuestionEvaluationResponse;
 import com.gotcha.server.evaluation.repository.EvaluationRepository;
 import com.gotcha.server.evaluation.repository.OneLinerRepository;
 import com.gotcha.server.global.exception.AppException;
@@ -62,5 +64,14 @@ public class EvaluationService {
         Applicant applicant = applicantRepository.findById(request.applicantId())
                 .orElseThrow(() -> new AppException(ErrorCode.APPLICANT_NOT_FOUNT));
         oneLinerRepository.save(new OneLiner(applicant, request.content(), interviewer));
+    }
+
+    public QuestionEvaluationResponse findQuestionEvaluations(final Long questionId) {
+        IndividualQuestion question = individualQuestionRepository.findById(questionId)
+                .orElseThrow(() -> new AppException(ErrorCode.QUESTION_NOT_FOUNT));
+        List<EvaluationResponse> evaluations = evaluationRepository.findAllByQuestion(question).stream()
+                .map(e -> new EvaluationResponse(e.getScore(), e.getContent()))
+                .toList();
+        return new QuestionEvaluationResponse(question.getContent(), question.isCommon(), evaluations);
     }
 }

--- a/src/main/java/com/gotcha/server/evaluation/service/QuestionEvaluations.java
+++ b/src/main/java/com/gotcha/server/evaluation/service/QuestionEvaluations.java
@@ -19,9 +19,7 @@ public class QuestionEvaluations {
         return questions.stream()
                 .collect(Collectors.toMap(
                         question -> question,
-                        question -> question.getEvaluations().stream()
-                                .mapToInt(Evaluation::getScore)
-                                .sum()));
+                        question -> question.calculateEvaluationScore()));
     }
 
     public List<IndividualQuestion> calculateQuestionsRank() {

--- a/src/main/java/com/gotcha/server/evaluation/service/QuestionEvaluations.java
+++ b/src/main/java/com/gotcha/server/evaluation/service/QuestionEvaluations.java
@@ -1,0 +1,40 @@
+package com.gotcha.server.evaluation.service;
+
+import com.gotcha.server.evaluation.domain.Evaluation;
+import com.gotcha.server.evaluation.dto.response.QuestionRankResponse;
+import com.gotcha.server.question.domain.IndividualQuestion;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class QuestionEvaluations {
+    private final Map<IndividualQuestion, Integer> totalQuestionsScore;
+
+    public QuestionEvaluations(final List<IndividualQuestion> questions) {
+        this.totalQuestionsScore = calculateTotalQuestionsScore(questions);
+    }
+
+    public Map<IndividualQuestion, Integer> calculateTotalQuestionsScore(final List<IndividualQuestion> questions) {
+        return questions.stream()
+                .collect(Collectors.toMap(
+                        question -> question,
+                        question -> question.getEvaluations().stream()
+                                .mapToInt(Evaluation::getScore)
+                                .sum()));
+    }
+
+    public List<IndividualQuestion> calculateQuestionsRank() {
+        List<IndividualQuestion> ranks = new ArrayList<>(totalQuestionsScore.keySet());
+        ranks.sort((questionId1, questionId2) ->
+                        totalQuestionsScore.get(questionId2).compareTo(totalQuestionsScore.get(questionId1)));
+        return ranks;
+    }
+
+    public List<QuestionRankResponse> createQuestionRanks() {
+        List<IndividualQuestion> ranks = calculateQuestionsRank();
+        return ranks.stream()
+                .map(question -> new QuestionRankResponse(question.getId(), totalQuestionsScore.get(question)))
+                .toList();
+    }
+}

--- a/src/main/java/com/gotcha/server/evaluation/service/QuestionEvaluations.java
+++ b/src/main/java/com/gotcha/server/evaluation/service/QuestionEvaluations.java
@@ -1,6 +1,5 @@
 package com.gotcha.server.evaluation.service;
 
-import com.gotcha.server.evaluation.domain.Evaluation;
 import com.gotcha.server.evaluation.dto.response.QuestionRankResponse;
 import com.gotcha.server.question.domain.IndividualQuestion;
 import java.util.ArrayList;
@@ -9,13 +8,13 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class QuestionEvaluations {
-    private final Map<IndividualQuestion, Integer> totalQuestionsScore;
+    private final Map<IndividualQuestion, Double> totalQuestionsScore;
 
     public QuestionEvaluations(final List<IndividualQuestion> questions) {
         this.totalQuestionsScore = calculateTotalQuestionsScore(questions);
     }
 
-    public Map<IndividualQuestion, Integer> calculateTotalQuestionsScore(final List<IndividualQuestion> questions) {
+    public Map<IndividualQuestion, Double> calculateTotalQuestionsScore(final List<IndividualQuestion> questions) {
         return questions.stream()
                 .collect(Collectors.toMap(
                         question -> question,

--- a/src/main/java/com/gotcha/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/gotcha/server/global/exception/ErrorCode.java
@@ -23,7 +23,7 @@ public enum ErrorCode {
     INTERVIEW_NOT_FOUNT(HttpStatus.NOT_FOUND, "존재하지 않는 면접입니다."),
     QUESTION_NOT_FOUNT(HttpStatus.NOT_FOUND, "존재하지 않는 질문입니다."),
   
-    INVALID_INTERVIEW_STATUS(HttpStatus.INTERNAL_SERVER_ERROR, "유효하지 않은 면접 단계입니다.");
+    INVALID_INTERVIEW_STATUS(HttpStatus.INTERNAL_SERVER_ERROR, "유효하지 않은 면접 단계입니다."),
     UNABLE_TO_SEND_EMAIL(HttpStatus.INTERNAL_SERVER_ERROR, "이메일을 보낼 수 없습니다.");
     private HttpStatus httpStatus;
     private String message;

--- a/src/main/java/com/gotcha/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/gotcha/server/global/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     NO_PARAMETER(HttpStatus.BAD_REQUEST, " 파라미터가 없습니다."),
     NAME_IS_EMPTY(HttpStatus.BAD_REQUEST, "면접 이름을 입력해주세요."),
     INVALID_EMAIL(HttpStatus.BAD_REQUEST, "유효하지 않은 이메일 주소입니다."),
+    INVALID_IMPORTANCE(HttpStatus.BAD_REQUEST, "중요도의 범위는 3~5입니다."),
 
     PROJECT_NOT_FOUNT(HttpStatus.NOT_FOUND, "존재하지 않는 프로젝트입니다."),
     APPLICANT_NOT_FOUNT(HttpStatus.NOT_FOUND, "존재하지 않는 지원자입니다."),

--- a/src/main/java/com/gotcha/server/question/domain/IndividualQuestion.java
+++ b/src/main/java/com/gotcha/server/question/domain/IndividualQuestion.java
@@ -24,6 +24,8 @@ import lombok.NoArgsConstructor;
 @Entity(name = "individual_question")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class IndividualQuestion {
+    private static final int DEFAULT_IMPORTANCE = 1;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -61,7 +63,7 @@ public class IndividualQuestion {
     @Builder
     public IndividualQuestion(final String content, final Applicant applicant) {
         this.content = content;
-        this.importance = 0;
+        this.importance = DEFAULT_IMPORTANCE;
         this.questionOrder = 0;
         this.applicant = applicant;
         this.asking = false;
@@ -80,6 +82,13 @@ public class IndividualQuestion {
         this.questionOrder = questionOrder;
     }
 
+    public void setImportance(Integer importance) {
+        if(importance == null) {
+            importance = DEFAULT_IMPORTANCE;
+        }
+        this.importance = importance;
+    }
+
     public void askDuringInterview() {
         this.asking = true;
     }
@@ -92,5 +101,15 @@ public class IndividualQuestion {
     public void removeEvaluation(final Evaluation evaluation) {
         evaluations.remove(evaluation);
         evaluation.setQuestion(null);
+    }
+
+    public Integer multiplyWeight(final int score) {
+        return score * importance;
+    }
+
+    public Integer calculateEvaluationScore() {
+        return multiplyWeight(evaluations.stream()
+                .mapToInt(Evaluation::getScore)
+                .sum());
     }
 }

--- a/src/main/java/com/gotcha/server/question/domain/IndividualQuestion.java
+++ b/src/main/java/com/gotcha/server/question/domain/IndividualQuestion.java
@@ -2,6 +2,8 @@ package com.gotcha.server.question.domain;
 
 import com.gotcha.server.applicant.domain.Applicant;
 import com.gotcha.server.applicant.domain.Interviewer;
+import com.gotcha.server.evaluation.domain.Evaluation;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -10,6 +12,9 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -50,6 +55,9 @@ public class IndividualQuestion {
     @Column(nullable = false)
     private boolean isCommon;
 
+    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Evaluation> evaluations = new ArrayList<>();
+
     @Builder
     public IndividualQuestion(final String content, final Applicant applicant) {
         this.content = content;
@@ -70,5 +78,19 @@ public class IndividualQuestion {
 
     public void setQuestionOrder(final Integer questionOrder) {
         this.questionOrder = questionOrder;
+    }
+
+    public void askDuringInterview() {
+        this.asking = true;
+    }
+
+    public void addEvaluation(final Evaluation evaluation) {
+        evaluations.add(evaluation);
+        evaluation.setQuestion(this);
+    }
+
+    public void removeEvaluation(final Evaluation evaluation) {
+        evaluations.remove(evaluation);
+        evaluation.setQuestion(null);
     }
 }

--- a/src/main/java/com/gotcha/server/question/repository/IndividualQuestionRepository.java
+++ b/src/main/java/com/gotcha/server/question/repository/IndividualQuestionRepository.java
@@ -5,7 +5,6 @@ import com.gotcha.server.question.domain.IndividualQuestion;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface IndividualQuestionRepository extends JpaRepository<IndividualQuestion, Long> {
-    List<IndividualQuestion> findAllByApplicantOrderByQuestionOrder(Applicant applicant);
+public interface IndividualQuestionRepository extends JpaRepository<IndividualQuestion, Long>, QuestionDslRepository {
     List<IndividualQuestion> findAllByIdIn(List<Long> ids);
 }

--- a/src/main/java/com/gotcha/server/question/repository/QuestionDslRepository.java
+++ b/src/main/java/com/gotcha/server/question/repository/QuestionDslRepository.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface QuestionDslRepository {
     List<IndividualQuestion> findAllDuringInterview(Applicant applicant);
+    List<IndividualQuestion> findAllAfterEvaluation(Applicant applicant);
 }

--- a/src/main/java/com/gotcha/server/question/repository/QuestionDslRepository.java
+++ b/src/main/java/com/gotcha/server/question/repository/QuestionDslRepository.java
@@ -1,0 +1,9 @@
+package com.gotcha.server.question.repository;
+
+import com.gotcha.server.applicant.domain.Applicant;
+import com.gotcha.server.question.domain.IndividualQuestion;
+import java.util.List;
+
+public interface QuestionDslRepository {
+    List<IndividualQuestion> findAllDuringInterview(Applicant applicant);
+}

--- a/src/main/java/com/gotcha/server/question/repository/QuestionDslRepositoryImpl.java
+++ b/src/main/java/com/gotcha/server/question/repository/QuestionDslRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.gotcha.server.question.repository;
+
+import com.gotcha.server.applicant.domain.Applicant;
+import com.gotcha.server.question.domain.IndividualQuestion;
+import com.gotcha.server.question.domain.QIndividualQuestion;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class QuestionDslRepositoryImpl implements QuestionDslRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<IndividualQuestion> findAllDuringInterview(Applicant applicant) {
+        QIndividualQuestion qQuestion = QIndividualQuestion.individualQuestion;
+
+        return jpaQueryFactory
+                .select(qQuestion)
+                .from(qQuestion)
+                .where(qQuestion.applicant.eq(applicant), qQuestion.asking.eq(true))
+                .orderBy(qQuestion.questionOrder.asc())
+                .fetch();
+    }
+}

--- a/src/main/java/com/gotcha/server/question/repository/QuestionDslRepositoryImpl.java
+++ b/src/main/java/com/gotcha/server/question/repository/QuestionDslRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.gotcha.server.question.repository;
 
 import com.gotcha.server.applicant.domain.Applicant;
+import com.gotcha.server.evaluation.domain.QEvaluation;
 import com.gotcha.server.question.domain.IndividualQuestion;
 import com.gotcha.server.question.domain.QIndividualQuestion;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -21,6 +22,21 @@ public class QuestionDslRepositoryImpl implements QuestionDslRepository {
                 .select(qQuestion)
                 .from(qQuestion)
                 .where(qQuestion.applicant.eq(applicant), qQuestion.asking.eq(true))
+                .orderBy(qQuestion.questionOrder.asc())
+                .fetch();
+    }
+
+    @Override
+    public List<IndividualQuestion> findAllAfterEvaluation(Applicant applicant) {
+        QIndividualQuestion qQuestion = QIndividualQuestion.individualQuestion;
+        QEvaluation qEvaluation = QEvaluation.evaluation;
+
+        return jpaQueryFactory
+                .select(qQuestion)
+                .from(qQuestion)
+                .where(qQuestion.applicant.eq(applicant), qQuestion.asking.eq(true))
+                .innerJoin(qQuestion.evaluations, qEvaluation)
+                .fetchJoin()
                 .orderBy(qQuestion.questionOrder.asc())
                 .fetch();
     }

--- a/src/main/java/com/gotcha/server/question/service/QuestionService.java
+++ b/src/main/java/com/gotcha/server/question/service/QuestionService.java
@@ -42,7 +42,7 @@ public class QuestionService {
     public List<InterviewQuestionResponse> listInterviewQuestions(final Long applicantId) {
         Applicant applicant = applicantRepository.findById(applicantId)
                 .orElseThrow(() -> new AppException(ErrorCode.APPLICANT_NOT_FOUNT));
-        List<IndividualQuestion> questions = individualQuestionRepository.findAllByApplicantOrderByQuestionOrder(applicant);
+        List<IndividualQuestion> questions = individualQuestionRepository.findAllDuringInterview(applicant);
         return InterviewQuestionResponse.generateList(questions);
     }
 }

--- a/src/test/java/com/gotcha/server/applicant/repository/ApplicantRepositoryTest.java
+++ b/src/test/java/com/gotcha/server/applicant/repository/ApplicantRepositoryTest.java
@@ -23,7 +23,7 @@ class ApplicantRepositoryTest extends RepositoryTest {
     private ApplicantRepository applicantRepository;
 
     @Test
-    @DisplayName("면접 별로 지원자를 조회할 때 면접관의 프로필도 조회한다.")
+    @DisplayName("면접 별로 지원자를 조회할 때 면접관의 이메일도 조회한다.")
     void 면접별_지원자_조회하기() {
         // given
         Member 종미 = 테스트유저("종미");
@@ -59,7 +59,7 @@ class ApplicantRepositoryTest extends RepositoryTest {
                 .containsAll(List.of("지원자A", "지원자B", "지원자C"));
         assertThat(조회결과)
                 .filteredOn(a -> a.getName().equals("지원자A"))
-                .flatExtracting(ApplicantsResponse::getInterviewerProfiles)
+                .flatExtracting(ApplicantsResponse::getInterviewerEmails)
                 .hasSize(2);
     }
 

--- a/src/test/java/com/gotcha/server/applicant/repository/ApplicantRepositoryTest.java
+++ b/src/test/java/com/gotcha/server/applicant/repository/ApplicantRepositoryTest.java
@@ -6,9 +6,12 @@ import static com.gotcha.server.common.TestFixture.테스트지원자;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.gotcha.server.applicant.domain.Applicant;
+import com.gotcha.server.applicant.domain.InterviewStatus;
 import com.gotcha.server.applicant.domain.Interviewer;
 import com.gotcha.server.applicant.domain.KeywordType;
+import com.gotcha.server.applicant.domain.Outcome;
 import com.gotcha.server.applicant.dto.response.ApplicantsResponse;
+import com.gotcha.server.applicant.dto.response.PassedApplicantsResponse;
 import com.gotcha.server.common.RepositoryTest;
 import com.gotcha.server.member.domain.Member;
 import com.gotcha.server.project.domain.Interview;
@@ -93,5 +96,32 @@ class ApplicantRepositoryTest extends RepositoryTest {
                 .filteredOn(a -> a.getName().equals("지원자A"))
                 .flatExtracting(ApplicantsResponse::getKeywords)
                 .hasSize(3);
+    }
+
+    @Test
+    @DisplayName("합격한 지원자들을 조회한다.")
+    void 합격한_지원자목록_조회하기() {
+        // given
+        Project 조회할프로젝트 = 테스트프로젝트();
+        Interview 조회할면접 = 테스트면접(조회할프로젝트, "테스트면접1");
+        Applicant 합격지원자A = 평가된_지원자_생성하기(조회할면접, "지원자A", Outcome.PASS);
+        Applicant 합격지원자B = 평가된_지원자_생성하기(조회할면접, "지원자B", Outcome.PASS);
+        Applicant 미평가지원자 = 테스트지원자(조회할면접, "지원자C");
+        Applicant 불합격지원자 = 평가된_지원자_생성하기(조회할면접, "지원자D", Outcome.FAIL);
+        testRepository.save(조회할프로젝트, 조회할면접, 합격지원자A, 합격지원자B, 미평가지원자, 불합격지원자);
+
+        // when
+        List<PassedApplicantsResponse> 조회결과 = applicantRepository.findAllPassedApplicantsWithKeywords(조회할면접);
+
+        // then
+        assertThat(조회결과).hasSize(2);
+    }
+
+    private Applicant 평가된_지원자_생성하기(Interview 면접, String 이름, Outcome 결과) {
+        Applicant 지원자 = 테스트지원자(면접, 이름);
+        지원자.moveToNextStatus();
+        지원자.moveToNextStatus();
+        지원자.determineOutcome(결과);
+        return 지원자;
     }
 }

--- a/src/test/java/com/gotcha/server/applicant/service/ApplicantServiceTest.java
+++ b/src/test/java/com/gotcha/server/applicant/service/ApplicantServiceTest.java
@@ -31,7 +31,7 @@ class ApplicantServiceTest extends IntegrationTest {
         environ.테스트키워드_저장하기(지원자A, "SQL자격증", KeywordType.SKILL);
 
         // when
-        ApplicantResponse 조회결과 = applicantService.findApplicantById(지원자A.getId());
+        ApplicantResponse 조회결과 = applicantService.findApplicantDetailsById(지원자A.getId());
 
         // then
         assertEquals("지원자A", 조회결과.getName());

--- a/src/test/java/com/gotcha/server/common/IntegrationTestEnviron.java
+++ b/src/test/java/com/gotcha/server/common/IntegrationTestEnviron.java
@@ -58,8 +58,8 @@ public class IntegrationTestEnviron {
         return keywordRepository.save(테스트키워드(지원자, 내용, 종류));
     }
 
-    public IndividualQuestion 테스트개별질문_저장하기(Applicant 지원자, String 내용, Integer 순서, boolean 면접때질문하기) {
-        return individualQuestionRepository.save(테스트개별질문(지원자, 내용, 순서, 면접때질문하기));
+    public IndividualQuestion 테스트개별질문_저장하기(Applicant 지원자, String 내용, Integer 순서, boolean 면접때질문하기, Integer 중요도) {
+        return individualQuestionRepository.save(테스트개별질문(지원자, 내용, 순서, 면접때질문하기, 중요도));
     }
 
     public Evaluation 테스트평가_저장하기(Integer 점수, String 평가내용, IndividualQuestion 질문, Interviewer 면접관) {

--- a/src/test/java/com/gotcha/server/common/IntegrationTestEnviron.java
+++ b/src/test/java/com/gotcha/server/common/IntegrationTestEnviron.java
@@ -9,6 +9,8 @@ import com.gotcha.server.applicant.domain.KeywordType;
 import com.gotcha.server.applicant.repository.ApplicantRepository;
 import com.gotcha.server.applicant.repository.InterviewerRepository;
 import com.gotcha.server.applicant.repository.KeywordRepository;
+import com.gotcha.server.evaluation.domain.Evaluation;
+import com.gotcha.server.evaluation.repository.EvaluationRepository;
 import com.gotcha.server.member.domain.Member;
 import com.gotcha.server.member.repository.MemberRepository;
 import com.gotcha.server.project.domain.Interview;
@@ -30,6 +32,7 @@ public class IntegrationTestEnviron {
     private final InterviewerRepository interviewerRepository;
     private final KeywordRepository keywordRepository;
     private final IndividualQuestionRepository individualQuestionRepository;
+    private final EvaluationRepository evaluationRepository;
 
     public Member 테스트유저_저장하기(String 이름) {
         return memberRepository.save(테스트유저(이름));
@@ -55,7 +58,11 @@ public class IntegrationTestEnviron {
         return keywordRepository.save(테스트키워드(지원자, 내용, 종류));
     }
 
-    public IndividualQuestion 테스트개별질문_저장하기(Applicant 지원자, String 내용, Integer 순서) {
-        return individualQuestionRepository.save(테스트개별질문(지원자, 내용, 순서));
+    public IndividualQuestion 테스트개별질문_저장하기(Applicant 지원자, String 내용, Integer 순서, boolean 면접때질문하기) {
+        return individualQuestionRepository.save(테스트개별질문(지원자, 내용, 순서, 면접때질문하기));
+    }
+
+    public Evaluation 테스트평가_저장하기(Integer 점수, String 평가내용, IndividualQuestion 질문, Interviewer 면접관) {
+        return evaluationRepository.save(테스트평가(점수, 평가내용, 질문, 면접관));
     }
 }

--- a/src/test/java/com/gotcha/server/common/TestFixture.java
+++ b/src/test/java/com/gotcha/server/common/TestFixture.java
@@ -52,12 +52,13 @@ public class TestFixture {
         return new Subcollaborator(이메일, 인터뷰);
     }
 
-    public static IndividualQuestion 테스트개별질문(Applicant 지원자, String 내용, Integer 순서, boolean 면접때질문하기) {
+    public static IndividualQuestion 테스트개별질문(Applicant 지원자, String 내용, Integer 순서, boolean 면접때질문하기, Integer 중요도) {
         IndividualQuestion question = IndividualQuestion.builder()
                 .applicant(지원자)
                 .content(내용)
                 .build();
         question.setQuestionOrder(순서);
+        question.setImportance(중요도);
         if(면접때질문하기) {
             question.askDuringInterview();
         }

--- a/src/test/java/com/gotcha/server/common/TestFixture.java
+++ b/src/test/java/com/gotcha/server/common/TestFixture.java
@@ -4,6 +4,7 @@ import com.gotcha.server.applicant.domain.Applicant;
 import com.gotcha.server.applicant.domain.Interviewer;
 import com.gotcha.server.applicant.domain.Keyword;
 import com.gotcha.server.applicant.domain.KeywordType;
+import com.gotcha.server.evaluation.domain.Evaluation;
 import com.gotcha.server.member.domain.Member;
 import com.gotcha.server.project.domain.Collaborator;
 import com.gotcha.server.project.domain.Interview;
@@ -51,12 +52,24 @@ public class TestFixture {
         return new Subcollaborator(이메일, 인터뷰);
     }
 
-    public static IndividualQuestion 테스트개별질문(Applicant 지원자, String 내용, Integer 순서) {
+    public static IndividualQuestion 테스트개별질문(Applicant 지원자, String 내용, Integer 순서, boolean 면접때질문하기) {
         IndividualQuestion question = IndividualQuestion.builder()
                 .applicant(지원자)
                 .content(내용)
                 .build();
         question.setQuestionOrder(순서);
+        if(면접때질문하기) {
+            question.askDuringInterview();
+        }
         return question;
+    }
+
+    public static Evaluation 테스트평가(Integer 점수, String 평가내용, IndividualQuestion 질문, Interviewer 면접관) {
+        return Evaluation.builder()
+                .score(점수)
+                .content(평가내용)
+                .interviewer(면접관)
+                .question(질문)
+                .build();
     }
 }

--- a/src/test/java/com/gotcha/server/evaluation/service/EvaluationServiceTest.java
+++ b/src/test/java/com/gotcha/server/evaluation/service/EvaluationServiceTest.java
@@ -42,8 +42,8 @@ class EvaluationServiceTest extends IntegrationTest {
         Applicant 지원자A = environ.테스트지원자_저장하기(테스트면접, "지원자A");
         environ.테스트면접관_저장하기(지원자A, 종미);
 
-        IndividualQuestion 질문A = environ.테스트개별질문_저장하기(지원자A, "자기소개해주세요.", 1, true);
-        IndividualQuestion 질문B = environ.테스트개별질문_저장하기(지원자A, "장점을소개해주세요.", 2, true);
+        IndividualQuestion 질문A = environ.테스트개별질문_저장하기(지원자A, "자기소개해주세요.", 1, true, 1);
+        IndividualQuestion 질문B = environ.테스트개별질문_저장하기(지원자A, "장점을소개해주세요.", 2, true, 1);
 
         List<EvaluateRequest> 평가요청 = List.of(
                 new EvaluateRequest(질문A.getId(), 4, "좋은인상이있음"), new EvaluateRequest(질문B.getId(), 1, "낫배드"));
@@ -66,8 +66,8 @@ class EvaluationServiceTest extends IntegrationTest {
         Interviewer 종미면접관 = environ.테스트면접관_저장하기(지원자A, 종미);
         Interviewer 윤정면접관 = environ.테스트면접관_저장하기(지원자A, 윤정);
 
-        IndividualQuestion 질문A = environ.테스트개별질문_저장하기(지원자A, "자기소개해주세요.", 1, true);
-        IndividualQuestion 질문B = environ.테스트개별질문_저장하기(지원자A, "장점을소개해주세요.", 2, true);
+        IndividualQuestion 질문A = environ.테스트개별질문_저장하기(지원자A, "자기소개해주세요.", 1, true, 1);
+        IndividualQuestion 질문B = environ.테스트개별질문_저장하기(지원자A, "장점을소개해주세요.", 2, true, 1);
 
         environ.테스트평가_저장하기(1, "인상이좋다", 질문A, 종미면접관);
         environ.테스트평가_저장하기(2, "굿", 질문A, 윤정면접관);
@@ -109,8 +109,8 @@ class EvaluationServiceTest extends IntegrationTest {
         Interviewer 종미면접관 = environ.테스트면접관_저장하기(지원자A, 종미);
         Interviewer 윤정면접관 = environ.테스트면접관_저장하기(지원자A, 윤정);
 
-        IndividualQuestion 질문A = environ.테스트개별질문_저장하기(지원자A, "자기소개해주세요.", 1, true);
-        IndividualQuestion 질문B = environ.테스트개별질문_저장하기(지원자A, "장점을소개해주세요.", 2, true);
+        IndividualQuestion 질문A = environ.테스트개별질문_저장하기(지원자A, "자기소개해주세요.", 1, true, 1);
+        IndividualQuestion 질문B = environ.테스트개별질문_저장하기(지원자A, "장점을소개해주세요.", 2, true, 1);
 
         environ.테스트평가_저장하기(1, "인상이좋다", 질문A, 종미면접관);
         environ.테스트평가_저장하기(2, "굿", 질문A, 윤정면접관);

--- a/src/test/java/com/gotcha/server/evaluation/service/EvaluationServiceTest.java
+++ b/src/test/java/com/gotcha/server/evaluation/service/EvaluationServiceTest.java
@@ -1,23 +1,36 @@
 package com.gotcha.server.evaluation.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.gotcha.server.applicant.domain.Applicant;
+import com.gotcha.server.applicant.domain.Interviewer;
 import com.gotcha.server.auth.security.MemberDetails;
 import com.gotcha.server.common.IntegrationTest;
+import com.gotcha.server.evaluation.domain.Evaluation;
 import com.gotcha.server.evaluation.dto.request.EvaluateRequest;
-import com.gotcha.server.evaluation.repository.EvaluationRepository;
 import com.gotcha.server.member.domain.Member;
 import com.gotcha.server.project.domain.Interview;
 import com.gotcha.server.project.domain.Project;
 import com.gotcha.server.question.domain.IndividualQuestion;
+import com.gotcha.server.question.repository.IndividualQuestionRepository;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+@Slf4j
 class EvaluationServiceTest extends IntegrationTest {
     @Autowired
     private EvaluationService evaluationService;
+
+    @Autowired
+    private IndividualQuestionRepository individualQuestionRepository;
 
     @Test
     void 지원자_평가하기() {
@@ -28,8 +41,8 @@ class EvaluationServiceTest extends IntegrationTest {
         Applicant 지원자A = environ.테스트지원자_저장하기(테스트면접, "지원자A");
         environ.테스트면접관_저장하기(지원자A, 종미);
 
-        IndividualQuestion 질문A = environ.테스트개별질문_저장하기(지원자A, "자기소개해주세요.", 1);
-        IndividualQuestion 질문B = environ.테스트개별질문_저장하기(지원자A, "장점을소개해주세요.", 2);
+        IndividualQuestion 질문A = environ.테스트개별질문_저장하기(지원자A, "자기소개해주세요.", 1, true);
+        IndividualQuestion 질문B = environ.테스트개별질문_저장하기(지원자A, "장점을소개해주세요.", 2, true);
 
         List<EvaluateRequest> 평가요청 = List.of(
                 new EvaluateRequest(질문A.getId(), 4, "좋은인상이있음"), new EvaluateRequest(질문B.getId(), 1, "낫배드"));
@@ -39,4 +52,48 @@ class EvaluationServiceTest extends IntegrationTest {
             evaluationService.evaluate(new MemberDetails(종미), 평가요청);
         });
     }
+
+    @Test
+    @DisplayName("질문별 총점을 구하는 로직을 구현하기 전 테스트한다.")
+    void 질문별_총점_계산하기() {
+        // given
+        Member 종미 = environ.테스트유저_저장하기("종미");
+        Member 윤정 = environ.테스트유저_저장하기("윤정");
+        Project 테스트프로젝트 = environ.테스트프로젝트_저장하기();
+        Interview 테스트면접 = environ.테스트면접_저장하기(테스트프로젝트, "테스트면접");
+        Applicant 지원자A = environ.테스트지원자_저장하기(테스트면접, "지원자A");
+        Interviewer 종미면접관 = environ.테스트면접관_저장하기(지원자A, 종미);
+        Interviewer 윤정면접관 = environ.테스트면접관_저장하기(지원자A, 윤정);
+
+        IndividualQuestion 질문A = environ.테스트개별질문_저장하기(지원자A, "자기소개해주세요.", 1, true);
+        IndividualQuestion 질문B = environ.테스트개별질문_저장하기(지원자A, "장점을소개해주세요.", 2, true);
+
+        environ.테스트평가_저장하기(1, "인상이좋다", 질문A, 종미면접관);
+        environ.테스트평가_저장하기(2, "굿", 질문A, 윤정면접관);
+        environ.테스트평가_저장하기(3, "좋은장점이다", 질문B, 종미면접관);
+        environ.테스트평가_저장하기(4, "좋다", 질문B, 윤정면접관);
+
+        // when
+        List<IndividualQuestion> 평가된_질문들 = individualQuestionRepository.findAllAfterEvaluation(지원자A);
+        Map<Long, Integer> 평가된_질문들_점수합 = 평가된_질문들.stream()
+                .collect(Collectors.toMap(
+                        IndividualQuestion::getId,
+                        question -> question.getEvaluations().stream()
+                                .mapToInt(Evaluation::getScore)
+                                .sum()
+                ));
+
+        List<Long> 질문순위 = new ArrayList<>(평가된_질문들_점수합.keySet());
+        질문순위.sort(
+                (questionId1, questionId2) ->
+                        평가된_질문들_점수합.get(questionId2).compareTo(평가된_질문들_점수합.get(questionId1)));
+
+        // then
+        assertThat(평가된_질문들).hasSize(2)
+                .extracting(IndividualQuestion::getEvaluations)
+                .satisfies(evaluations -> assertThat(evaluations).hasSize(2));
+        assertEquals(3, 평가된_질문들_점수합.get(질문A.getId()));
+        assertEquals(7, 평가된_질문들_점수합.get(질문B.getId()));
+        assertEquals(질문B.getId(), 질문순위.get(0));
+        }
 }

--- a/src/test/java/com/gotcha/server/evaluation/service/EvaluationServiceTest.java
+++ b/src/test/java/com/gotcha/server/evaluation/service/EvaluationServiceTest.java
@@ -10,6 +10,7 @@ import com.gotcha.server.auth.security.MemberDetails;
 import com.gotcha.server.common.IntegrationTest;
 import com.gotcha.server.evaluation.domain.Evaluation;
 import com.gotcha.server.evaluation.dto.request.EvaluateRequest;
+import com.gotcha.server.evaluation.dto.response.QuestionRankResponse;
 import com.gotcha.server.member.domain.Member;
 import com.gotcha.server.project.domain.Interview;
 import com.gotcha.server.project.domain.Project;
@@ -84,8 +85,7 @@ class EvaluationServiceTest extends IntegrationTest {
                 ));
 
         List<Long> 질문순위 = new ArrayList<>(평가된_질문들_점수합.keySet());
-        질문순위.sort(
-                (questionId1, questionId2) ->
+        질문순위.sort((questionId1, questionId2) ->
                         평가된_질문들_점수합.get(questionId2).compareTo(평가된_질문들_점수합.get(questionId1)));
 
         // then
@@ -95,5 +95,34 @@ class EvaluationServiceTest extends IntegrationTest {
         assertEquals(3, 평가된_질문들_점수합.get(질문A.getId()));
         assertEquals(7, 평가된_질문들_점수합.get(질문B.getId()));
         assertEquals(질문B.getId(), 질문순위.get(0));
-        }
+    }
+
+    @Test
+    @DisplayName("지원자의 각 질문들의 총점과 순위를 구한다.")
+    void 질문별_총점_계산하기2() {
+        // given
+        Member 종미 = environ.테스트유저_저장하기("종미");
+        Member 윤정 = environ.테스트유저_저장하기("윤정");
+        Project 테스트프로젝트 = environ.테스트프로젝트_저장하기();
+        Interview 테스트면접 = environ.테스트면접_저장하기(테스트프로젝트, "테스트면접");
+        Applicant 지원자A = environ.테스트지원자_저장하기(테스트면접, "지원자A");
+        Interviewer 종미면접관 = environ.테스트면접관_저장하기(지원자A, 종미);
+        Interviewer 윤정면접관 = environ.테스트면접관_저장하기(지원자A, 윤정);
+
+        IndividualQuestion 질문A = environ.테스트개별질문_저장하기(지원자A, "자기소개해주세요.", 1, true);
+        IndividualQuestion 질문B = environ.테스트개별질문_저장하기(지원자A, "장점을소개해주세요.", 2, true);
+
+        environ.테스트평가_저장하기(1, "인상이좋다", 질문A, 종미면접관);
+        environ.테스트평가_저장하기(2, "굿", 질문A, 윤정면접관);
+        environ.테스트평가_저장하기(3, "좋은장점이다", 질문B, 종미면접관);
+        environ.테스트평가_저장하기(4, "좋다", 질문B, 윤정면접관);
+
+        // when
+        List<QuestionRankResponse> 조회결과 = evaluationService.findQuestionRanks(지원자A.getId());
+
+        // then
+        assertThat(조회결과).hasSize(2)
+                .extracting(QuestionRankResponse::totalScore)
+                .containsExactlyElementsOf(List.of(7, 3));
+    }
 }

--- a/src/test/java/com/gotcha/server/evaluation/service/EvaluationServiceTest.java
+++ b/src/test/java/com/gotcha/server/evaluation/service/EvaluationServiceTest.java
@@ -123,6 +123,6 @@ class EvaluationServiceTest extends IntegrationTest {
         // then
         assertThat(조회결과).hasSize(2)
                 .extracting(QuestionRankResponse::totalScore)
-                .containsExactlyElementsOf(List.of(7, 3));
+                .containsExactlyElementsOf(List.of(3.5, 1.5));
     }
 }


### PR DESCRIPTION
## Check 🌈

- [x] merge할 브랜치가 dev인가요? (main ❌)
- [x] merge는 PR 작성자가 합니다

## Description 📒

>구현한 기능 목록입니다.
>1. (면접 후) 지원자의 지원자의 모든 질문별 총점과 질문 순위를 조회하는 기능
>2. (면접 후) 지원자의 모든 질문별 면접관들의 평가를 조회하는 기능
>3. 합격자 목록 조회 기능
>4. 면접의 모든 지원자에게 합/불 이메일 보내는 기능(이 때, interview status 바뀜)

## To Reviewer 💬

지원자 총점 평균 계산할 때 `QuestionEvaluations` 활용하면 코드 재사용할 수 있을 거 같습니당
저는 일단 질문별 순위랑 총점 필요해서 그 부분 로직만 작성했습니다.
```java
public class QuestionEvaluations {
    /*
     한 지원자의 모든 면접 중 사용된 질문(key)과 그 질문의 총점(value)을 map으로 저장한다.
     이 때, 총점이란 질문의 '모든 면접관들의 점수의 합 * 가중치(중요도)를 면접관 수로 나눈 것'이다.
    */
    private final Map<IndividualQuestion, Double> totalQuestionsScore;
    // ..생략
    
    // 질문들의 순위를 구한다.
    public List<IndividualQuestion> calculateQuestionsRank() {
        List<IndividualQuestion> ranks = new ArrayList<>(totalQuestionsScore.keySet());
        ranks.sort((questionId1, questionId2) ->
                        totalQuestionsScore.get(questionId2).compareTo(totalQuestionsScore.get(questionId1)));
        return ranks;
    }
```