### PR TITLE
면접 준비 중의 지원자 상세 페이지와 면접 후 페이지 관련 기능 구현

### DIFF
--- a/src/main/java/com/gotcha/server/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/gotcha/server/applicant/controller/ApplicantController.java
@@ -13,14 +13,10 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-@RestController("/api/applicants")
+@RestController
+@RequestMapping(value = "/api/applicants")
 @RequiredArgsConstructor
 public class ApplicantController {
     private final ApplicantService applicantService;

--- a/src/main/java/com/gotcha/server/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/gotcha/server/applicant/controller/ApplicantController.java
@@ -75,7 +75,12 @@ public class ApplicantController {
     }
 
     @GetMapping("/interview-completed")
-    public ResponseEntity<List<CompletedApplicantsResponse>> getCompletedApplicants(@RequestParam Long interviewId){
+    public ResponseEntity<List<CompletedApplicantsResponse>> getCompletedApplicants(@RequestParam(value = "interview-id") Long interviewId){
         return ResponseEntity.status(HttpStatus.OK).body(applicantService.getCompletedApplicants(interviewId));
+    }
+
+    @GetMapping("/interview-completed/details")
+    public ResponseEntity<CompletedApplicantDetailsResponse> getCompletedApplicantDetails(@RequestParam(value = "applicant-id") Long applicantId){
+        return ResponseEntity.status(HttpStatus.OK).body(applicantService.getCompletedApplicantDetails(applicantId));
     }
 }

--- a/src/main/java/com/gotcha/server/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/gotcha/server/applicant/controller/ApplicantController.java
@@ -1,5 +1,6 @@
 package com.gotcha.server.applicant.controller;
 
+import com.gotcha.server.applicant.dto.request.ApplicantRequest;
 import com.gotcha.server.applicant.dto.request.InterviewProceedRequest;
 import com.gotcha.server.applicant.dto.request.PassEmailSendRequest;
 import com.gotcha.server.applicant.dto.response.ApplicantResponse;
@@ -10,7 +11,13 @@ import com.gotcha.server.applicant.dto.response.TodayInterviewResponse;
 import com.gotcha.server.applicant.service.ApplicantService;
 import com.gotcha.server.auth.security.MemberDetails;
 import java.util.List;
+
+import com.gotcha.server.member.domain.Member;
+import com.gotcha.server.member.repository.MemberRepository;
+import com.gotcha.server.project.dto.request.ProjectRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -20,6 +27,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class ApplicantController {
     private final ApplicantService applicantService;
+    private final MemberRepository memberRepository;
 
     @PostMapping("/interview-ready")
     public ResponseEntity<InterviewProceedResponse> proceedToInterview(
@@ -51,5 +59,23 @@ public class ApplicantController {
     public ResponseEntity<Void> sendPassEmail(@RequestBody final PassEmailSendRequest request) {
         applicantService.sendPassEmail(request);
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping
+    public ResponseEntity<String> createApplicant(
+            @RequestBody @Valid ApplicantRequest request,
+            @AuthenticationPrincipal MemberDetails details) {
+        //테스트용 유저 생성
+        Member member = Member.builder()
+                .email("a@gmail.co")
+                .socialId("socialId")
+                .name("이름")
+                .profileUrl("a.jpg")
+                .refreshToken("token")
+                .build();
+        memberRepository.save(member);
+        applicantService.createApplicant(request, member);
+//        applicantService.createApplicant(request, details.member());
+        return ResponseEntity.status(HttpStatus.CREATED).body("면접 지원자 정보가 입력되었습니다.");
     }
 }

--- a/src/main/java/com/gotcha/server/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/gotcha/server/applicant/controller/ApplicantController.java
@@ -3,18 +3,13 @@ package com.gotcha.server.applicant.controller;
 import com.gotcha.server.applicant.dto.request.ApplicantRequest;
 import com.gotcha.server.applicant.dto.request.InterviewProceedRequest;
 import com.gotcha.server.applicant.dto.request.PassEmailSendRequest;
-import com.gotcha.server.applicant.dto.response.ApplicantResponse;
-import com.gotcha.server.applicant.dto.response.ApplicantsResponse;
-import com.gotcha.server.applicant.dto.response.InterviewProceedResponse;
-import com.gotcha.server.applicant.dto.response.PassedApplicantsResponse;
-import com.gotcha.server.applicant.dto.response.TodayInterviewResponse;
+import com.gotcha.server.applicant.dto.response.*;
 import com.gotcha.server.applicant.service.ApplicantService;
 import com.gotcha.server.auth.security.MemberDetails;
 import java.util.List;
 
 import com.gotcha.server.member.domain.Member;
 import com.gotcha.server.member.repository.MemberRepository;
-import com.gotcha.server.project.dto.request.ProjectRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -77,5 +72,10 @@ public class ApplicantController {
         applicantService.createApplicant(request, member);
 //        applicantService.createApplicant(request, details.member());
         return ResponseEntity.status(HttpStatus.CREATED).body("면접 지원자 정보가 입력되었습니다.");
+    }
+
+    @GetMapping("/interview-completed")
+    public ResponseEntity<List<CompletedApplicantsResponse>> getCompletedApplicants(@RequestParam Long interviewId){
+        return ResponseEntity.status(HttpStatus.OK).body(applicantService.getCompletedApplicants(interviewId));
     }
 }

--- a/src/main/java/com/gotcha/server/applicant/domain/Applicant.java
+++ b/src/main/java/com/gotcha/server/applicant/domain/Applicant.java
@@ -12,10 +12,13 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -36,6 +39,9 @@ public class Applicant {
 
     @OneToMany(mappedBy = "applicant", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<IndividualQuestion> questions = new ArrayList<>();
+
+    @OneToMany(mappedBy = "applicant", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Keyword> keywords = new ArrayList<>();
 
     @Column(nullable = false)
     private Outcome outcome;
@@ -63,6 +69,7 @@ public class Applicant {
         this.outcome = Outcome.PENDING;
         this.interviewStatus = InterviewStatus.PREPARATION;
         this.ranking = 0;
+        this.totalScore = 0;
     }
 
     public void moveToNextStatus() {
@@ -93,11 +100,43 @@ public class Applicant {
         question.setApplicant(null);
     }
 
+    public void addKeyword(Keyword keyword) {
+        keywords.add(keyword);
+        keyword.setApplicant(this);
+    }
+
+    public void removeKeyword(Keyword keyword) {
+        keywords.remove(keyword);
+        keyword.setApplicant(null);
+    }
+
     public void setDate(LocalDate date) {
         this.date = date;
     }
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    @Builder
+    public Applicant(Interview interview, List<Interviewer> interviewers, List<IndividualQuestion> questions, List<Keyword> keywords, String email, LocalDate date, String name, Integer age, String education, String phoneNumber, String position, String path, String resumeLink, String portfolio) {
+        this.interview = interview;
+        this.interviewers = interviewers;
+        this.questions = questions;
+        this.keywords = keywords;
+        this.email = email;
+        this.date = date;
+        this.name = name;
+        this.age = age;
+        this.education = education;
+        this.phoneNumber = phoneNumber;
+        this.position = position;
+        this.path = path;
+        this.resumeLink = resumeLink;
+        this.portfolio = portfolio;
+        this.outcome = Outcome.PENDING;
+        this.interviewStatus = InterviewStatus.PREPARATION;
+        this.ranking = 0;
+        this.totalScore = 0;
     }
 }

--- a/src/main/java/com/gotcha/server/applicant/domain/Applicant.java
+++ b/src/main/java/com/gotcha/server/applicant/domain/Applicant.java
@@ -25,7 +25,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Applicant {
+public class Applicant implements Comparable<Applicant> {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -60,7 +60,7 @@ public class Applicant {
     private String position;
     private String path;
     private Integer totalScore;
-    private int ranking;
+    private Integer ranking;
     private String resumeLink;
     private String portfolio;
 
@@ -70,6 +70,14 @@ public class Applicant {
         this.interviewStatus = InterviewStatus.PREPARATION;
         this.ranking = 0;
         this.totalScore = 0;
+    }
+
+    public void updateRanking(Integer ranking){
+        this.ranking = ranking;
+    }
+
+    public void updateTotalScore(Integer totalScore){
+        this.totalScore = totalScore;
     }
 
     public void moveToNextStatus() {
@@ -120,6 +128,11 @@ public class Applicant {
 
     public void setEmail(String email){
         this.email = email;
+    }
+
+    @Override
+    public int compareTo(Applicant other) {
+        return Integer.compare(this.getTotalScore(), other.getTotalScore());
     }
 
     @Builder

--- a/src/main/java/com/gotcha/server/applicant/domain/Applicant.java
+++ b/src/main/java/com/gotcha/server/applicant/domain/Applicant.java
@@ -118,6 +118,10 @@ public class Applicant {
         this.name = name;
     }
 
+    public void setEmail(String email){
+        this.email = email;
+    }
+
     @Builder
     public Applicant(Interview interview, List<Interviewer> interviewers, List<IndividualQuestion> questions, List<Keyword> keywords, String email, LocalDate date, String name, Integer age, String education, String phoneNumber, String position, String path, String resumeLink, String portfolio) {
         this.interview = interview;

--- a/src/main/java/com/gotcha/server/applicant/domain/Interviewer.java
+++ b/src/main/java/com/gotcha/server/applicant/domain/Interviewer.java
@@ -28,9 +28,12 @@ public class Interviewer {
     @JoinColumn(nullable = false, name = "member_id")
     private Member member;
 
-    public Interviewer(final Applicant applicant, final Member member) {
+    private String name;
+
+    public Interviewer(final Applicant applicant, final Member member, final String name) {
         this.applicant = applicant;
         this.member = member;
+        this.name = name;
     }
 
     public void setApplicant(Applicant applicant) {

--- a/src/main/java/com/gotcha/server/applicant/domain/Keyword.java
+++ b/src/main/java/com/gotcha/server/applicant/domain/Keyword.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -29,6 +30,8 @@ public class Keyword {
     @Column(nullable = false)
     private KeywordType keywordType;
 
+
+    @Builder
     public Keyword(final Applicant applicant, final String name, final KeywordType keywordType) {
         this.applicant = applicant;
         this.name = name;

--- a/src/main/java/com/gotcha/server/applicant/dto/request/ApplicantRequest.java
+++ b/src/main/java/com/gotcha/server/applicant/dto/request/ApplicantRequest.java
@@ -2,8 +2,7 @@ package com.gotcha.server.applicant.dto.request;
 
 import com.gotcha.server.applicant.domain.*;
 import com.gotcha.server.project.domain.Interview;
-import com.gotcha.server.question.domain.IndividualQuestion;
-import jakarta.persistence.*;
+import com.gotcha.server.question.dto.request.IndividualQuestionRequest;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/gotcha/server/applicant/dto/request/ApplicantRequest.java
+++ b/src/main/java/com/gotcha/server/applicant/dto/request/ApplicantRequest.java
@@ -1,0 +1,71 @@
+package com.gotcha.server.applicant.dto.request;
+
+import com.gotcha.server.applicant.domain.*;
+import com.gotcha.server.project.domain.Interview;
+import com.gotcha.server.question.domain.IndividualQuestion;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ApplicantRequest {
+
+    private String name;
+    private LocalDate date;
+    private List<InterviewerRequest> interviewers;
+    private Integer age;
+    private String education;
+    private String position;
+    private String phoneNumber;
+    private String path;
+    private String email;
+    private List<KeywordRequest> keywords;
+    private String resumeLink;
+    private String portfolio;
+    private Interview interview;
+    private List<IndividualQuestionRequest> questions;
+
+    @Builder
+    public ApplicantRequest(String name, LocalDate date, List<InterviewerRequest> interviewers, Integer age, String education, String position, String phoneNumber, String path, String email, List<KeywordRequest> keywords, String resumeLink, String portfolio, Interview interview, List<IndividualQuestionRequest> questions) {
+        this.name = name;
+        this.date = date;
+        this.interviewers = interviewers;
+        this.age = age;
+        this.education = education;
+        this.position = position;
+        this.phoneNumber = phoneNumber;
+        this.path = path;
+        this.email = email;
+        this.keywords = keywords;
+        this.resumeLink = resumeLink;
+        this.portfolio = portfolio;
+        this.interview = interview;
+        this.questions = questions;
+    }
+
+    public Applicant toEntity() {
+        return Applicant.builder()
+                .name(name)
+                .date(date)
+                .age(age)
+                .education(education)
+                .position(position)
+                .phoneNumber(phoneNumber)
+                .path(path)
+                .email(email)
+                .resumeLink(resumeLink)
+                .portfolio(portfolio)
+                .interview(interview)
+                .questions(new ArrayList<>())
+                .keywords(new ArrayList<>())
+                .interviewers(new ArrayList<>())
+                .build();
+    }
+}
+

--- a/src/main/java/com/gotcha/server/applicant/dto/request/IndividualQuestionRequest.java
+++ b/src/main/java/com/gotcha/server/applicant/dto/request/IndividualQuestionRequest.java
@@ -1,0 +1,32 @@
+package com.gotcha.server.applicant.dto.request;
+
+import com.gotcha.server.applicant.domain.Applicant;
+import com.gotcha.server.applicant.domain.Keyword;
+import com.gotcha.server.applicant.domain.KeywordType;
+import com.gotcha.server.member.domain.Member;
+import com.gotcha.server.question.domain.IndividualQuestion;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class IndividualQuestionRequest {
+
+    private String content;
+    private Applicant applicant;
+
+    @Builder
+    public IndividualQuestionRequest(String content, Applicant applicant) {
+        this.content = content;
+        this.applicant = applicant;
+    }
+
+    public IndividualQuestion toEntity(Member member){
+        return IndividualQuestion.builder()
+                .content(content)
+                .applicant(applicant)
+                .member(member)
+                .build();
+    }
+}

--- a/src/main/java/com/gotcha/server/applicant/dto/request/InterviewerRequest.java
+++ b/src/main/java/com/gotcha/server/applicant/dto/request/InterviewerRequest.java
@@ -1,0 +1,4 @@
+package com.gotcha.server.applicant.dto.request;
+
+public class InterviewerRequest {
+}

--- a/src/main/java/com/gotcha/server/applicant/dto/request/KeywordRequest.java
+++ b/src/main/java/com/gotcha/server/applicant/dto/request/KeywordRequest.java
@@ -1,0 +1,32 @@
+package com.gotcha.server.applicant.dto.request;
+
+import com.gotcha.server.applicant.domain.Applicant;
+import com.gotcha.server.applicant.domain.Keyword;
+import com.gotcha.server.applicant.domain.KeywordType;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class KeywordRequest {
+
+    private Applicant applicant;
+    private String name;
+    private KeywordType keywordType;
+
+    @Builder
+    public KeywordRequest(Applicant applicant, String name, KeywordType keywordType) {
+        this.applicant = applicant;
+        this.name = name;
+        this.keywordType = keywordType;
+    }
+
+    public Keyword toEntity() {
+        return Keyword.builder()
+                .applicant(applicant)
+                .name(name)
+                .keywordType(keywordType)
+                .build();
+    }
+}

--- a/src/main/java/com/gotcha/server/applicant/dto/response/CompletedApplicantDetailsResponse.java
+++ b/src/main/java/com/gotcha/server/applicant/dto/response/CompletedApplicantDetailsResponse.java
@@ -1,0 +1,43 @@
+package com.gotcha.server.applicant.dto.response;
+
+import com.gotcha.server.applicant.domain.Applicant;
+import com.gotcha.server.applicant.domain.InterviewStatus;
+import com.gotcha.server.evaluation.dto.response.OneLinerResponse;
+import com.gotcha.server.project.domain.Interview;
+import com.gotcha.server.project.dto.response.InterviewListResponse;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor
+public class CompletedApplicantDetailsResponse {
+    private String applicantName;
+    private Integer totalScore;
+    private Integer ranking;
+    private List<KeywordResponse> keywords;
+    private List<OneLinerResponse> oneLiners;
+
+    @Builder
+    public CompletedApplicantDetailsResponse(String applicantName, Integer totalScore, Integer ranking, List<KeywordResponse> keywords, List<OneLinerResponse> oneLiners) {
+        this.applicantName = applicantName;
+        this.totalScore = totalScore;
+        this.ranking = ranking;
+        this.keywords = keywords;
+        this.oneLiners = oneLiners;
+    }
+
+    public static CompletedApplicantDetailsResponse from(Applicant applicant, List<KeywordResponse> keywords, List<OneLinerResponse> oneLiners){
+        return CompletedApplicantDetailsResponse.builder()
+                .applicantName(applicant.getName())
+                .totalScore(applicant.getTotalScore())
+                .ranking(applicant.getRanking())
+                .keywords(keywords)
+                .oneLiners(oneLiners)
+                .build();
+    }
+}

--- a/src/main/java/com/gotcha/server/applicant/dto/response/CompletedApplicantsResponse.java
+++ b/src/main/java/com/gotcha/server/applicant/dto/response/CompletedApplicantsResponse.java
@@ -1,0 +1,60 @@
+package com.gotcha.server.applicant.dto.response;
+
+import com.gotcha.server.applicant.domain.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor
+public class CompletedApplicantsResponse {
+    private String interviewName;
+    private String applicantName;
+    private LocalDate date;
+    private List<String> interviewers;
+    private String email;
+    private List<KeywordResponse> keywords;
+    private Integer totalScore;
+    private int ranking;
+    private InterviewStatus interviewStatus;
+
+    @Builder
+    public CompletedApplicantsResponse(String interviewName, List<String> interviewers, List<KeywordResponse> keywords, String email, LocalDate date, String name, InterviewStatus interviewStatus, Integer totalScore, int ranking) {
+        this.interviewName = interviewName;
+        this.interviewers = interviewers;
+        this.keywords = keywords;
+        this.email = email;
+        this.date = date;
+        this.applicantName = name;
+        this.interviewStatus = interviewStatus;
+        this.totalScore = totalScore;
+        this.ranking = ranking;
+    }
+
+    public static List<CompletedApplicantsResponse> generateList(List<Applicant> applicants, Map<Applicant, List<KeywordResponse>> keywordMap) {
+        return applicants.stream()
+                .map(applicant -> CompletedApplicantsResponse.builder()
+                        .interviewName(applicant.getInterview().getName())
+                        .interviewers(getInterviewersNames(applicant))
+                        .keywords(keywordMap.get(applicant))
+                        .email(applicant.getEmail())
+                        .date(applicant.getDate())
+                        .name(applicant.getName())
+                        .interviewStatus(applicant.getInterviewStatus())
+                        .totalScore(applicant.getTotalScore())
+                        .ranking(applicant.getRanking())
+                        .build())
+                .toList();
+    }
+
+    private static List<String> getInterviewersNames(Applicant applicant) {
+        return applicant.getInterviewers().stream()
+                .map(Interviewer::getName)
+                .toList();
+    }
+}
+

--- a/src/main/java/com/gotcha/server/applicant/dto/response/CompletedApplicantsResponse.java
+++ b/src/main/java/com/gotcha/server/applicant/dto/response/CompletedApplicantsResponse.java
@@ -1,6 +1,7 @@
 package com.gotcha.server.applicant.dto.response;
 
 import com.gotcha.server.applicant.domain.*;
+import com.gotcha.server.evaluation.dto.response.OneLinerResponse;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,9 +22,10 @@ public class CompletedApplicantsResponse {
     private Integer totalScore;
     private int ranking;
     private InterviewStatus interviewStatus;
+    private List<OneLinerResponse> oneLiners;
 
     @Builder
-    public CompletedApplicantsResponse(String interviewName, List<String> interviewers, List<KeywordResponse> keywords, String email, LocalDate date, String name, InterviewStatus interviewStatus, Integer totalScore, int ranking) {
+    public CompletedApplicantsResponse(String interviewName, List<String> interviewers, List<KeywordResponse> keywords, String email, LocalDate date, String name, InterviewStatus interviewStatus, Integer totalScore, int ranking, List<OneLinerResponse> oneLiners) {
         this.interviewName = interviewName;
         this.interviewers = interviewers;
         this.keywords = keywords;
@@ -33,14 +35,16 @@ public class CompletedApplicantsResponse {
         this.interviewStatus = interviewStatus;
         this.totalScore = totalScore;
         this.ranking = ranking;
+        this.oneLiners = oneLiners;
     }
 
-    public static List<CompletedApplicantsResponse> generateList(List<Applicant> applicants, Map<Applicant, List<KeywordResponse>> keywordMap) {
+    public static List<CompletedApplicantsResponse> generateList(List<Applicant> applicants, Map<Applicant, List<KeywordResponse>> keywordMap, Map<Applicant, List<OneLinerResponse>> oneLinerMap) {
         return applicants.stream()
                 .map(applicant -> CompletedApplicantsResponse.builder()
                         .interviewName(applicant.getInterview().getName())
                         .interviewers(getInterviewersNames(applicant))
                         .keywords(keywordMap.get(applicant))
+                        .oneLiners(oneLinerMap.get(applicant))
                         .email(applicant.getEmail())
                         .date(applicant.getDate())
                         .name(applicant.getName())
@@ -57,4 +61,3 @@ public class CompletedApplicantsResponse {
                 .toList();
     }
 }
-

--- a/src/main/java/com/gotcha/server/applicant/dto/response/CompletedApplicantsResponse.java
+++ b/src/main/java/com/gotcha/server/applicant/dto/response/CompletedApplicantsResponse.java
@@ -20,12 +20,12 @@ public class CompletedApplicantsResponse {
     private String email;
     private List<KeywordResponse> keywords;
     private Integer totalScore;
-    private int ranking;
+    private Integer ranking;
     private InterviewStatus interviewStatus;
     private List<OneLinerResponse> oneLiners;
 
     @Builder
-    public CompletedApplicantsResponse(String interviewName, List<String> interviewers, List<KeywordResponse> keywords, String email, LocalDate date, String name, InterviewStatus interviewStatus, Integer totalScore, int ranking, List<OneLinerResponse> oneLiners) {
+    public CompletedApplicantsResponse(String interviewName, List<String> interviewers, List<KeywordResponse> keywords, String email, LocalDate date, String name, InterviewStatus interviewStatus, Integer totalScore, Integer ranking, List<OneLinerResponse> oneLiners) {
         this.interviewName = interviewName;
         this.interviewers = interviewers;
         this.keywords = keywords;

--- a/src/main/java/com/gotcha/server/applicant/repository/ApplicantDslRepository.java
+++ b/src/main/java/com/gotcha/server/applicant/repository/ApplicantDslRepository.java
@@ -1,11 +1,15 @@
 package com.gotcha.server.applicant.repository;
 
+import com.gotcha.server.applicant.domain.Applicant;
 import com.gotcha.server.applicant.dto.response.ApplicantsResponse;
+import com.gotcha.server.applicant.dto.response.KeywordResponse;
 import com.gotcha.server.applicant.dto.response.PassedApplicantsResponse;
 import com.gotcha.server.project.domain.Interview;
 import java.util.List;
+import java.util.Map;
 
 public interface ApplicantDslRepository {
-    List<ApplicantsResponse> findAllByInterviewWithKeywords(Interview interview);
+    Map<Applicant, List<KeywordResponse>> findAllByInterviewWithKeywords(List<Applicant> applicants, final Interview interview);
+    List<ApplicantsResponse> generateApplicantsResponse(final Interview interview);
     List<PassedApplicantsResponse> findAllPassedApplicantsWithKeywords(Interview interview);
 }

--- a/src/main/java/com/gotcha/server/applicant/repository/ApplicantDslRepository.java
+++ b/src/main/java/com/gotcha/server/applicant/repository/ApplicantDslRepository.java
@@ -12,4 +12,5 @@ public interface ApplicantDslRepository {
     Map<Applicant, List<KeywordResponse>> findAllByInterviewWithKeywords(List<Applicant> applicants, final Interview interview);
     List<ApplicantsResponse> generateApplicantsResponse(final Interview interview);
     List<PassedApplicantsResponse> findAllPassedApplicantsWithKeywords(Interview interview);
+    List<KeywordResponse> findKeywordsByApplicant(Applicant applicant);
 }

--- a/src/main/java/com/gotcha/server/applicant/repository/ApplicantDslRepositoryImpl.java
+++ b/src/main/java/com/gotcha/server/applicant/repository/ApplicantDslRepositoryImpl.java
@@ -50,6 +50,20 @@ public class ApplicantDslRepositoryImpl implements ApplicantDslRepository {
         return keywordMap;
     }
 
+    @Override
+    public List<KeywordResponse> findKeywordsByApplicant(Applicant applicant) {
+        QKeyword qKeyword = QKeyword.keyword;
+        List<Tuple> keywords = findAllKeywordByApplicants(List.of(applicant));
+
+        return keywords.stream()
+                .map(tuple -> {
+                    String minName = tuple.get(qKeyword.name.min());
+                    KeywordType keywordType = tuple.get(qKeyword.keywordType);
+                    return new KeywordResponse(minName, keywordType);
+                })
+                .collect(Collectors.toList());
+    }
+
     private List<Applicant> findAllApplicants(final Interview interview) {
         QApplicant qApplicant = QApplicant.applicant;
         QInterviewer qInterviewer = QInterviewer.interviewer;

--- a/src/main/java/com/gotcha/server/applicant/repository/ApplicantDslRepositoryImpl.java
+++ b/src/main/java/com/gotcha/server/applicant/repository/ApplicantDslRepositoryImpl.java
@@ -28,10 +28,15 @@ public class ApplicantDslRepositoryImpl implements ApplicantDslRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<ApplicantsResponse> findAllByInterviewWithKeywords(final Interview interview) {
-        QKeyword qKeyword = QKeyword.keyword;
-
+    public List<ApplicantsResponse> generateApplicantsResponse(final Interview interview) {
         List<Applicant> applicants = findAllApplicants(interview);
+        final Map<Applicant, List<KeywordResponse>> keywordMap = findAllByInterviewWithKeywords(applicants, interview);
+        return ApplicantsResponse.generateList(applicants, keywordMap);
+    } // to-do: service 단으로 옮기는게 좋아보인다
+
+    @Override
+    public Map<Applicant, List<KeywordResponse>> findAllByInterviewWithKeywords(List<Applicant> applicants, final Interview interview){
+        QKeyword qKeyword = QKeyword.keyword;
         List<Tuple> keywords = findAllKeywordByApplicants(applicants);
 
         Map<Applicant, List<KeywordResponse>> keywordMap = applicants.stream()
@@ -42,8 +47,7 @@ public class ApplicantDslRepositoryImpl implements ApplicantDslRepository {
             KeywordType keywordType = tuple.get(qKeyword.keywordType);
             keywordMap.get(applicant).add(new KeywordResponse(minName, keywordType));
         });
-
-        return ApplicantsResponse.generateList(applicants, keywordMap);
+        return keywordMap;
     }
 
     private List<Applicant> findAllApplicants(final Interview interview) {

--- a/src/main/java/com/gotcha/server/applicant/repository/InterviewerRepository.java
+++ b/src/main/java/com/gotcha/server/applicant/repository/InterviewerRepository.java
@@ -3,6 +3,8 @@ package com.gotcha.server.applicant.repository;
 import com.gotcha.server.applicant.domain.Applicant;
 import com.gotcha.server.applicant.domain.Interviewer;
 import com.gotcha.server.member.domain.Member;
+
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -16,4 +18,7 @@ public interface InterviewerRepository extends JpaRepository<Interviewer, Long> 
             + "join i.applicant a "
             + "where i.member = :member and a.date = current_date()")
     long countTodayInterview(@Param("member") Member member);
+
+    @Query("SELECT i.name FROM Interviewer i WHERE i.applicant.id = :applicationId")
+    List<String> findInterviewerNamesByApplicationId(@Param("applicationId") Long applicationId);
 }

--- a/src/main/java/com/gotcha/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/gotcha/server/applicant/service/ApplicantService.java
@@ -189,4 +189,13 @@ public class ApplicantService {
 
     public void setTotalScore(List<Applicant> applicants){
     }
+
+    public CompletedApplicantDetailsResponse getCompletedApplicantDetails(Long applicantId){
+        final Applicant applicant = applicantRepository.findById(applicantId)
+                .orElseThrow(() -> new AppException(ErrorCode.APPLICANT_NOT_FOUNT));
+
+        final List<KeywordResponse> keywords = applicantRepository.findKeywordsByApplicant(applicant);
+        final List<OneLinerResponse> oneLiners = oneLinerRepository.getOneLinersForApplicant(applicant);
+        return CompletedApplicantDetailsResponse.from(applicant, keywords, oneLiners);
+    }
 }

--- a/src/main/java/com/gotcha/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/gotcha/server/applicant/service/ApplicantService.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.gotcha.server.question.domain.IndividualQuestion;
+import com.gotcha.server.question.dto.request.IndividualQuestionRequest;
 import com.gotcha.server.question.repository.IndividualQuestionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -145,6 +146,8 @@ public class ApplicantService {
                 .collect(Collectors.toList());
     }
 
-//    public List<Interviewer> createInterviewers() {
-//    }
+    //    public List<Interviewer> createInterviewers() {
+    //    }
+
+
 }

--- a/src/main/java/com/gotcha/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/gotcha/server/applicant/service/ApplicantService.java
@@ -5,11 +5,7 @@ import com.gotcha.server.applicant.domain.Interviewer;
 import com.gotcha.server.applicant.domain.Keyword;
 import com.gotcha.server.applicant.domain.PreparedInterviewer;
 import com.gotcha.server.applicant.dto.request.*;
-import com.gotcha.server.applicant.dto.response.ApplicantResponse;
-import com.gotcha.server.applicant.dto.response.ApplicantsResponse;
-import com.gotcha.server.applicant.dto.response.InterviewProceedResponse;
-import com.gotcha.server.applicant.dto.response.PassedApplicantsResponse;
-import com.gotcha.server.applicant.dto.response.TodayInterviewResponse;
+import com.gotcha.server.applicant.dto.response.*;
 import com.gotcha.server.applicant.repository.ApplicantRepository;
 import com.gotcha.server.applicant.repository.InterviewerRepository;
 import com.gotcha.server.applicant.repository.KeywordRepository;
@@ -23,6 +19,7 @@ import com.gotcha.server.project.domain.Interview;
 import com.gotcha.server.project.repository.InterviewRepository;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.gotcha.server.question.domain.IndividualQuestion;
@@ -74,7 +71,7 @@ public class ApplicantService {
     public List<ApplicantsResponse> listApplicantsByInterview(final Long interviewId) {
         Interview interview = interviewRepository.findById(interviewId)
                 .orElseThrow(() -> new AppException(ErrorCode.INTERVIEW_NOT_FOUNT));
-        return applicantRepository.findAllByInterviewWithKeywords(interview);
+        return applicantRepository.generateApplicantsResponse(interview);
     }
 
     public ApplicantResponse findApplicantDetailsById(final Long applicantId) {
@@ -149,5 +146,11 @@ public class ApplicantService {
     //    public List<Interviewer> createInterviewers() {
     //    }
 
-
+    public List<CompletedApplicantsResponse> getCompletedApplicants(Long interviewId) {
+        final Interview interview = interviewRepository.findById(interviewId)
+                .orElseThrow(() -> new AppException(ErrorCode.INTERVIEW_NOT_FOUNT));
+        final List<Applicant> applicants = applicantRepository.findAllByInterview(interview);
+        final Map<Applicant, List<KeywordResponse>> keywordMap = applicantRepository.findAllByInterviewWithKeywords(applicants, interview);
+        return CompletedApplicantsResponse.generateList(applicants, keywordMap);
+    }
 }

--- a/src/main/java/com/gotcha/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/gotcha/server/applicant/service/ApplicantService.java
@@ -11,6 +11,9 @@ import com.gotcha.server.applicant.repository.InterviewerRepository;
 import com.gotcha.server.applicant.repository.KeywordRepository;
 import com.gotcha.server.applicant.repository.PreparedInterviewerRepository;
 import com.gotcha.server.auth.security.MemberDetails;
+import com.gotcha.server.evaluation.dto.response.OneLinerResponse;
+import com.gotcha.server.evaluation.repository.OneLinerRepository;
+import com.gotcha.server.evaluation.service.EvaluationService;
 import com.gotcha.server.global.exception.AppException;
 import com.gotcha.server.global.exception.ErrorCode;
 import com.gotcha.server.mail.service.MailService;
@@ -39,7 +42,7 @@ public class ApplicantService {
     private final InterviewRepository interviewRepository;
     private final KeywordRepository keywordRepository;
     private final MailService mailService;
-    private final IndividualQuestionRepository individualQuestionRepository;
+    private final OneLinerRepository oneLinerRepository;
 
     @Transactional
     public InterviewProceedResponse proceedToInterview(final InterviewProceedRequest request, final MemberDetails details) {
@@ -151,6 +154,7 @@ public class ApplicantService {
                 .orElseThrow(() -> new AppException(ErrorCode.INTERVIEW_NOT_FOUNT));
         final List<Applicant> applicants = applicantRepository.findAllByInterview(interview);
         final Map<Applicant, List<KeywordResponse>> keywordMap = applicantRepository.findAllByInterviewWithKeywords(applicants, interview);
-        return CompletedApplicantsResponse.generateList(applicants, keywordMap);
+        final Map<Applicant, List<OneLinerResponse>> oneLinerMap = oneLinerRepository.getOneLinersForApplicants(applicants);
+        return CompletedApplicantsResponse.generateList(applicants, keywordMap, oneLinerMap);
     }
 }

--- a/src/main/java/com/gotcha/server/evaluation/controller/EvaluationController.java
+++ b/src/main/java/com/gotcha/server/evaluation/controller/EvaluationController.java
@@ -11,14 +11,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-@RestController("/api/evaluations")
+@RestController
+@RequestMapping(value = "/api/evaluations")
 @RequiredArgsConstructor
 public class EvaluationController {
     private final EvaluationService evaluationService;

--- a/src/main/java/com/gotcha/server/evaluation/domain/Evaluation.java
+++ b/src/main/java/com/gotcha/server/evaluation/domain/Evaluation.java
@@ -2,6 +2,7 @@ package com.gotcha.server.evaluation.domain;
 
 import com.gotcha.server.applicant.domain.Interviewer;
 import com.gotcha.server.global.domain.BaseTimeEntity;
+import com.gotcha.server.member.domain.Member;
 import com.gotcha.server.question.domain.IndividualQuestion;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -28,16 +29,16 @@ public class Evaluation extends BaseTimeEntity {
     private IndividualQuestion question;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "interviewer_id", nullable = false)
-    private Interviewer interviewer;
+    @JoinColumn(name = "writer_id", nullable = false)
+    private Member member;
 
     @Builder
     public Evaluation(final Integer score, final String content,
-            final IndividualQuestion question, final Interviewer interviewer) {
+            final IndividualQuestion question, final Member member) {
         this.score = score;
         this.content = content;
         this.question = question;
-        this.interviewer = interviewer;
+        this.member = member;
     }
 
     public void setQuestion(final IndividualQuestion question) {

--- a/src/main/java/com/gotcha/server/evaluation/domain/OneLiner.java
+++ b/src/main/java/com/gotcha/server/evaluation/domain/OneLiner.java
@@ -3,6 +3,7 @@ package com.gotcha.server.evaluation.domain;
 import com.gotcha.server.applicant.domain.Applicant;
 import com.gotcha.server.applicant.domain.Interviewer;
 import com.gotcha.server.global.domain.BaseTimeEntity;
+import com.gotcha.server.member.domain.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -24,12 +25,12 @@ public class OneLiner extends BaseTimeEntity {
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "interviewer_id", nullable = false)
-    private Interviewer interviewer;
+    @JoinColumn(name = "writer_id", nullable = false)
+    private Member member;
 
-    public OneLiner(final Applicant applicant, final String content, final Interviewer interviewer) {
+    public OneLiner(final Applicant applicant, final String content, final Member member) {
         this.applicant = applicant;
         this.content = content;
-        this.interviewer = interviewer;
+        this.member = member;
     }
 }

--- a/src/main/java/com/gotcha/server/evaluation/dto/response/OneLinerResponse.java
+++ b/src/main/java/com/gotcha/server/evaluation/dto/response/OneLinerResponse.java
@@ -1,0 +1,2 @@
+package com.gotcha.server.evaluation.dto.response;public class OneLinerResponse {
+}

--- a/src/main/java/com/gotcha/server/evaluation/dto/response/OneLinerResponse.java
+++ b/src/main/java/com/gotcha/server/evaluation/dto/response/OneLinerResponse.java
@@ -1,2 +1,6 @@
-package com.gotcha.server.evaluation.dto.response;public class OneLinerResponse {
+package com.gotcha.server.evaluation.dto.response;
+
+import com.gotcha.server.applicant.domain.Interviewer;
+
+public record OneLinerResponse(String writerName, String content) {
 }

--- a/src/main/java/com/gotcha/server/evaluation/repository/OneLinerDslRepository.java
+++ b/src/main/java/com/gotcha/server/evaluation/repository/OneLinerDslRepository.java
@@ -9,5 +9,6 @@ import java.util.List;
 import java.util.Map;
 
 public interface OneLinerDslRepository {
-    public Map<Applicant, List<OneLinerResponse>> getOneLinersForApplicants(List<Applicant> applicants);
+    Map<Applicant, List<OneLinerResponse>> getOneLinersForApplicants(List<Applicant> applicants);
+    List<OneLinerResponse> getOneLinersForApplicant(Applicant applicant);
 }

--- a/src/main/java/com/gotcha/server/evaluation/repository/OneLinerDslRepository.java
+++ b/src/main/java/com/gotcha/server/evaluation/repository/OneLinerDslRepository.java
@@ -1,0 +1,13 @@
+package com.gotcha.server.evaluation.repository;
+
+import com.gotcha.server.applicant.domain.Applicant;
+import com.gotcha.server.applicant.dto.response.KeywordResponse;
+import com.gotcha.server.evaluation.dto.response.OneLinerResponse;
+import com.gotcha.server.project.domain.Interview;
+
+import java.util.List;
+import java.util.Map;
+
+public interface OneLinerDslRepository {
+    public Map<Applicant, List<OneLinerResponse>> getOneLinersForApplicants(List<Applicant> applicants);
+}

--- a/src/main/java/com/gotcha/server/evaluation/repository/OneLinerDslRepositoryImpl.java
+++ b/src/main/java/com/gotcha/server/evaluation/repository/OneLinerDslRepositoryImpl.java
@@ -1,0 +1,42 @@
+package com.gotcha.server.evaluation.repository;
+
+import com.gotcha.server.applicant.domain.Applicant;
+import com.gotcha.server.evaluation.domain.QOneLiner;
+import com.gotcha.server.evaluation.dto.response.OneLinerResponse;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class OneLinerDslRepositoryImpl implements OneLinerDslRepository{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Map<Applicant, List<OneLinerResponse>> getOneLinersForApplicants(List<Applicant> applicants) {
+        QOneLiner qOneLiner = QOneLiner.oneLiner;
+
+        Map<Applicant, List<OneLinerResponse>> oneLinerMap = jpaQueryFactory
+                .select(qOneLiner.applicant, qOneLiner.content, qOneLiner.member.name)
+                .from(qOneLiner)
+                .where(qOneLiner.applicant.in(applicants))
+                .fetch()
+                .stream()
+                .collect(Collectors.groupingBy(
+                        tuple -> tuple.get(qOneLiner.applicant),
+                        Collectors.mapping(
+                                tuple -> new OneLinerResponse(
+                                        tuple.get(qOneLiner.member.name),
+                                        tuple.get(qOneLiner.content)
+                                ),
+                                Collectors.toList()
+                        )
+                ));
+        return oneLinerMap;
+    }
+}

--- a/src/main/java/com/gotcha/server/evaluation/repository/OneLinerDslRepositoryImpl.java
+++ b/src/main/java/com/gotcha/server/evaluation/repository/OneLinerDslRepositoryImpl.java
@@ -39,4 +39,21 @@ public class OneLinerDslRepositoryImpl implements OneLinerDslRepository{
                 ));
         return oneLinerMap;
     }
+
+    @Override
+    public List<OneLinerResponse> getOneLinersForApplicant(Applicant applicant) {
+        QOneLiner qOneLiner = QOneLiner.oneLiner;
+
+        return jpaQueryFactory
+                .select(qOneLiner.content, qOneLiner.member.name)
+                .from(qOneLiner)
+                .where(qOneLiner.applicant.eq(applicant))
+                .fetch()
+                .stream()
+                .map(tuple -> new OneLinerResponse(
+                        tuple.get(qOneLiner.member.name),
+                        tuple.get(qOneLiner.content)
+                ))
+                .toList();
+    }
 }

--- a/src/main/java/com/gotcha/server/evaluation/repository/OneLinerRepository.java
+++ b/src/main/java/com/gotcha/server/evaluation/repository/OneLinerRepository.java
@@ -1,9 +1,14 @@
 package com.gotcha.server.evaluation.repository;
 
+import com.gotcha.server.applicant.domain.Applicant;
+import com.gotcha.server.evaluation.domain.Evaluation;
 import com.gotcha.server.evaluation.domain.OneLiner;
+import com.gotcha.server.question.domain.IndividualQuestion;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-@Repository
-public interface OneLinerRepository extends JpaRepository<OneLiner, Long> {
+import java.util.List;
+
+
+public interface OneLinerRepository extends JpaRepository<OneLiner, Long>, OneLinerDslRepository{
 }

--- a/src/main/java/com/gotcha/server/evaluation/service/EvaluationService.java
+++ b/src/main/java/com/gotcha/server/evaluation/service/EvaluationService.java
@@ -38,8 +38,8 @@ public class EvaluationService {
 
     @Transactional
     public void evaluate(final MemberDetails details, final List<EvaluateRequest> requests) {
-        Interviewer interviewer = interviewerRepository.findByMember(details.member())
-                .orElseThrow(() -> new AppException(ErrorCode.UNAUTHORIZED_INTERVIEWER));
+//        Interviewer interviewer = interviewerRepository.findByMember(details.member())
+//                .orElseThrow(() -> new AppException(ErrorCode.UNAUTHORIZED_INTERVIEWER));
 
         List<IndividualQuestion> questions = getQuestionsBeingEvaluated(requests);
         Map<Long, IndividualQuestion> questionMap = questions.stream().collect(Collectors.toMap(IndividualQuestion::getId, q->q));
@@ -48,7 +48,7 @@ public class EvaluationService {
                         .score(request.score())
                         .content(request.content())
                         .question(questionMap.get(request.questionId()))
-                        .interviewer(interviewer)
+                        .member(details.member())
                         .build())
                 .toList();
         evaluationRepository.saveAll(evaluations);

--- a/src/main/java/com/gotcha/server/evaluation/service/EvaluationService.java
+++ b/src/main/java/com/gotcha/server/evaluation/service/EvaluationService.java
@@ -65,11 +65,11 @@ public class EvaluationService {
 
     @Transactional
     public void createOneLiner(final MemberDetails details, final OneLinerRequest request) {
-        Interviewer interviewer = interviewerRepository.findByMember(details.member())
-                .orElseThrow(() -> new AppException(ErrorCode.UNAUTHORIZED_INTERVIEWER));
+//        Interviewer interviewer = interviewerRepository.findByMember(details.member())
+//                .orElseThrow(() -> new AppException(ErrorCode.UNAUTHORIZED_INTERVIEWER));
         Applicant applicant = applicantRepository.findById(request.applicantId())
                 .orElseThrow(() -> new AppException(ErrorCode.APPLICANT_NOT_FOUNT));
-        oneLinerRepository.save(new OneLiner(applicant, request.content(), interviewer));
+        oneLinerRepository.save(new OneLiner(applicant, request.content(), details.member()));
     }
 
     public QuestionEvaluationResponse findQuestionEvaluations(final Long questionId) {

--- a/src/main/java/com/gotcha/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/gotcha/server/global/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     NAME_IS_EMPTY(HttpStatus.BAD_REQUEST, "면접 이름을 입력해주세요."),
     INVALID_EMAIL(HttpStatus.BAD_REQUEST, "유효하지 않은 이메일 주소입니다."),
     INVALID_IMPORTANCE(HttpStatus.BAD_REQUEST, "중요도의 범위는 3~5입니다."),
+    CONTENT_IS_EMPTY(HttpStatus.BAD_REQUEST, "내용을 입력해주세요."),
 
     PROJECT_NOT_FOUNT(HttpStatus.NOT_FOUND, "존재하지 않는 프로젝트입니다."),
     APPLICANT_NOT_FOUNT(HttpStatus.NOT_FOUND, "존재하지 않는 지원자입니다."),

--- a/src/main/java/com/gotcha/server/project/controller/InterviewController.java
+++ b/src/main/java/com/gotcha/server/project/controller/InterviewController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping(value = "api/interviews")
+@RequestMapping(value = "/api/interviews")
 public class InterviewController {
 
     private final InterviewService interviewService;

--- a/src/main/java/com/gotcha/server/project/controller/ProjectController.java
+++ b/src/main/java/com/gotcha/server/project/controller/ProjectController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping(value = "api/projects")
+@RequestMapping(value = "/api/projects")
 public class ProjectController {
 
     private final ProjectService projectService;

--- a/src/main/java/com/gotcha/server/project/service/ProjectService.java
+++ b/src/main/java/com/gotcha/server/project/service/ProjectService.java
@@ -31,7 +31,7 @@ public class ProjectService {
     private final MailService mailService;
     private final InterviewDslRepositoryImpl interviewDslRepository;
 
-    @Transactional(readOnly = true)
+
     public void createProject(ProjectRequest request) {
         validProject(request);
 
@@ -41,7 +41,6 @@ public class ProjectService {
         sendProjectInvitation(request);
     }
 
-    @Transactional(readOnly = true)
     public void createCollaborator(Project project, List<String> emails) {
         for (String email : emails) {
             Collaborator collaborator = Collaborator.builder()
@@ -52,7 +51,6 @@ public class ProjectService {
         }
     }
 
-    @Transactional(readOnly = true)
     public ProjectResponse getEmails(Long projectId) {
         List<String> emails = collaboratorRepository.findEmailsByProjectId(projectId);
         return ProjectResponse.from(emails);

--- a/src/main/java/com/gotcha/server/question/controller/QuestionController.java
+++ b/src/main/java/com/gotcha/server/question/controller/QuestionController.java
@@ -7,12 +7,10 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-@RestController("api/questions")
+@RestController
+@RequestMapping(value = "/api/questions")
 @RequiredArgsConstructor
 public class QuestionController {
     private final QuestionService questionService;

--- a/src/main/java/com/gotcha/server/question/controller/QuestionController.java
+++ b/src/main/java/com/gotcha/server/question/controller/QuestionController.java
@@ -1,12 +1,19 @@
 package com.gotcha.server.question.controller;
 
+import com.gotcha.server.member.domain.Member;
+import com.gotcha.server.member.repository.MemberRepository;
+import com.gotcha.server.question.dto.request.IndividualQuestionRequest;
+import com.gotcha.server.auth.security.MemberDetails;
 import com.gotcha.server.question.dto.request.CommonQuestionsRequest;
 import com.gotcha.server.question.dto.response.InterviewQuestionResponse;
 import com.gotcha.server.question.service.QuestionService;
 import java.util.List;
+
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -14,6 +21,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class QuestionController {
     private final QuestionService questionService;
+    private final MemberRepository memberRepository;
 
     @PostMapping("/common")
     public ResponseEntity<Void> createCommonQuestions(final CommonQuestionsRequest request) {
@@ -24,5 +32,24 @@ public class QuestionController {
     @GetMapping("/in-progress/{applicant-id}")
     public ResponseEntity<List<InterviewQuestionResponse>> findAllInterviewQuestions(@PathVariable(name = "applicant-id") Long applicantId) {
         return ResponseEntity.ok(questionService.listInterviewQuestions(applicantId));
+    }
+
+    @PostMapping("/individual")
+    public ResponseEntity<String> createIndividualQuestion(
+            @RequestBody @Valid IndividualQuestionRequest request,
+            @AuthenticationPrincipal MemberDetails details) {
+//        테스트용 유저 생성
+        Member member = Member.builder()
+                .email("a@gmail.co")
+                .socialId("socialId")
+                .name("이름")
+                .profileUrl("a.jpg")
+                .refreshToken("token")
+                .build();
+        memberRepository.save(member);
+
+        questionService.createIndividualQuestion(request, member);
+//        questionService.createIndividualQuestion(request, details.member());
+        return ResponseEntity.status(HttpStatus.CREATED).body("개별 질문이 입력되었습니다.");
     }
 }

--- a/src/main/java/com/gotcha/server/question/domain/IndividualQuestion.java
+++ b/src/main/java/com/gotcha/server/question/domain/IndividualQuestion.java
@@ -66,7 +66,7 @@ public class IndividualQuestion {
     private List<Evaluation> evaluations = new ArrayList<>();
 
     @Builder
-    public IndividualQuestion(final String content, final Applicant applicant, final Member member) {
+    public IndividualQuestion(final String content, final Applicant applicant, final Member member, final IndividualQuestion commentTarget) {
         this.content = content;
         this.importance = MIN_IMPORTANCE;
         this.questionOrder = 0;
@@ -74,6 +74,7 @@ public class IndividualQuestion {
         this.asking = false;
         this.isCommon = false;
         this.member = member;
+        this.commentTarget = commentTarget;
     }
 
     public void setApplicant(final Applicant applicant) {

--- a/src/main/java/com/gotcha/server/question/domain/IndividualQuestion.java
+++ b/src/main/java/com/gotcha/server/question/domain/IndividualQuestion.java
@@ -5,6 +5,7 @@ import com.gotcha.server.applicant.domain.Interviewer;
 import com.gotcha.server.evaluation.domain.Evaluation;
 import com.gotcha.server.global.exception.AppException;
 import com.gotcha.server.global.exception.ErrorCode;
+import com.gotcha.server.member.domain.Member;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -49,7 +50,7 @@ public class IndividualQuestion {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "writer_id")
-    private Interviewer interviewer;
+    private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "comment_target_id")
@@ -65,21 +66,18 @@ public class IndividualQuestion {
     private List<Evaluation> evaluations = new ArrayList<>();
 
     @Builder
-    public IndividualQuestion(final String content, final Applicant applicant) {
+    public IndividualQuestion(final String content, final Applicant applicant, final Member member) {
         this.content = content;
         this.importance = MIN_IMPORTANCE;
         this.questionOrder = 0;
         this.applicant = applicant;
         this.asking = false;
         this.isCommon = false;
+        this.member = member;
     }
 
     public void setApplicant(final Applicant applicant) {
         this.applicant = applicant;
-    }
-
-    public void setInterviewer(final Interviewer interviewer) {
-        this.interviewer = interviewer;
     }
 
     public void setQuestionOrder(final Integer questionOrder) {

--- a/src/main/java/com/gotcha/server/question/dto/request/IndividualQuestionRequest.java
+++ b/src/main/java/com/gotcha/server/question/dto/request/IndividualQuestionRequest.java
@@ -1,4 +1,4 @@
-package com.gotcha.server.applicant.dto.request;
+package com.gotcha.server.question.dto.request;
 
 import com.gotcha.server.applicant.domain.Applicant;
 import com.gotcha.server.applicant.domain.Keyword;
@@ -15,11 +15,13 @@ public class IndividualQuestionRequest {
 
     private String content;
     private Applicant applicant;
+    private IndividualQuestion commentTarget;
 
     @Builder
-    public IndividualQuestionRequest(String content, Applicant applicant) {
+    public IndividualQuestionRequest(String content, Applicant applicant, IndividualQuestion commentTarget) {
         this.content = content;
         this.applicant = applicant;
+        this.commentTarget = commentTarget;
     }
 
     public IndividualQuestion toEntity(Member member){
@@ -27,6 +29,7 @@ public class IndividualQuestionRequest {
                 .content(content)
                 .applicant(applicant)
                 .member(member)
+                .commentTarget(commentTarget)
                 .build();
     }
 }

--- a/src/main/java/com/gotcha/server/question/service/QuestionService.java
+++ b/src/main/java/com/gotcha/server/question/service/QuestionService.java
@@ -1,9 +1,11 @@
 package com.gotcha.server.question.service;
 
 import com.gotcha.server.applicant.domain.Applicant;
+import com.gotcha.server.question.dto.request.IndividualQuestionRequest;
 import com.gotcha.server.applicant.repository.ApplicantRepository;
 import com.gotcha.server.global.exception.AppException;
 import com.gotcha.server.global.exception.ErrorCode;
+import com.gotcha.server.member.domain.Member;
 import com.gotcha.server.project.domain.Interview;
 import com.gotcha.server.project.repository.InterviewRepository;
 import com.gotcha.server.question.domain.CommonQuestion;
@@ -19,7 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional(readOnly = true)
+@Transactional
 @RequiredArgsConstructor
 public class QuestionService {
     private final CommonQuestionRepository commonQuestionRepository;
@@ -44,5 +46,18 @@ public class QuestionService {
                 .orElseThrow(() -> new AppException(ErrorCode.APPLICANT_NOT_FOUNT));
         List<IndividualQuestion> questions = individualQuestionRepository.findAllDuringInterview(applicant);
         return InterviewQuestionResponse.generateList(questions);
+    }
+
+    public void createIndividualQuestion(IndividualQuestionRequest request, Member member){
+        validQuestion(request);
+
+        IndividualQuestion question = request.toEntity(member);
+        individualQuestionRepository.save(question);
+    }
+
+    public void validQuestion(IndividualQuestionRequest request){
+        if (request.getContent() == null || request.getContent().trim().isEmpty()) {
+            throw new AppException(ErrorCode.CONTENT_IS_EMPTY);
+        }
     }
 }

--- a/src/test/java/com/gotcha/server/applicant/repository/ApplicantRepositoryTest.java
+++ b/src/test/java/com/gotcha/server/applicant/repository/ApplicantRepositoryTest.java
@@ -54,7 +54,7 @@ class ApplicantRepositoryTest extends RepositoryTest {
                 종미면접관_지원자A, 종미면접관_지원자B, 종미면접관_지원자C, 윤정면접관_지원자A);
 
         // when
-        List<ApplicantsResponse> 조회결과 = applicantRepository.findAllByInterviewWithKeywords(조회할면접);
+        List<ApplicantsResponse> 조회결과 = applicantRepository.generateApplicantsResponse(조회할면접);
 
         // then
         assertThat(조회결과).hasSize(3)
@@ -89,7 +89,7 @@ class ApplicantRepositoryTest extends RepositoryTest {
                 테스트키워드(지원자B, "성실함", KeywordType.TRAIT), 테스트키워드(지원자B, "깔끔함", KeywordType.TRAIT));
 
         // when
-        List<ApplicantsResponse> 조회결과 = applicantRepository.findAllByInterviewWithKeywords(조회할면접);
+        List<ApplicantsResponse> 조회결과 = applicantRepository.generateApplicantsResponse(조회할면접);
 
         // then
         assertThat(조회결과).hasSize(2)

--- a/src/test/java/com/gotcha/server/applicant/repository/InterviewerRepositoryTest.java
+++ b/src/test/java/com/gotcha/server/applicant/repository/InterviewerRepositoryTest.java
@@ -1,14 +1,18 @@
 package com.gotcha.server.applicant.repository;
 
 import static com.gotcha.server.common.TestFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.gotcha.server.applicant.domain.Applicant;
+import com.gotcha.server.applicant.domain.Interviewer;
 import com.gotcha.server.common.RepositoryTest;
 import com.gotcha.server.member.domain.Member;
 import com.gotcha.server.project.domain.Interview;
 import com.gotcha.server.project.domain.Project;
 import java.time.LocalDate;
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,5 +45,29 @@ class InterviewerRepositoryTest extends RepositoryTest {
 
         // then
         assertEquals(2L, 조회된_면접_개수);
+    }
+
+    @Test
+    @DisplayName("지원자의 면접관 이름 목록을 조회한다.")
+    void findInterviewerNamesByApplicationId() {
+        // given
+        Member 종미 = 테스트유저("종미");
+        Member 윤정 = 테스트유저("윤정");
+        Project 테스트프로젝트 = 테스트프로젝트();
+        Interview 테스트면접 = 테스트면접(테스트프로젝트, "테스트면접");
+        Applicant 지원자A = 테스트지원자(테스트면접, "지원자A");
+        Interviewer 테스트면접관A = 테스트면접관(지원자A, 종미);
+        Interviewer 테스트면접관B = 테스트면접관(지원자A, 윤정);
+
+        testRepository.save(
+                종미, 윤정, 테스트프로젝트, 테스트면접, 지원자A, 테스트면접관A, 테스트면접관B
+        );
+
+        // when
+        List<String> 조회결과 = interviewerRepository.findInterviewerNamesByApplicationId(지원자A.getId());
+
+        // then
+        assertThat(조회결과).hasSize(2)
+                .containsAll(List.of("윤정", "종미"));
     }
 }

--- a/src/test/java/com/gotcha/server/common/TestFixture.java
+++ b/src/test/java/com/gotcha/server/common/TestFixture.java
@@ -33,11 +33,12 @@ public class TestFixture {
     public static Applicant 테스트지원자(Interview 면접, String 이름) {
         Applicant applicant = new Applicant(면접);
         applicant.setName(이름);
+        applicant.setEmail(String.format("%s email", 이름));
         return applicant;
     }
 
     public static Interviewer 테스트면접관(Applicant 지원자, Member 면접관) {
-        return new Interviewer(지원자, 면접관);
+        return new Interviewer(지원자, 면접관, 면접관.getName());
     }
 
     public static Keyword 테스트키워드(Applicant 지원자, String 내용, KeywordType 종류) {


### PR DESCRIPTION
## Check 🌈

- [x] merge할 브랜치가 dev인가요? (main ❌)
- [x] merge는 PR 작성자가 합니다

## Description 📒

1. 면접 결과에서 지원자 리스트 조회
        - 총점, 키워드, 개인 정보, 순위, 한줄평 조회
        - 점수 기준으로 랭킹 계산 및 정렬 기능 구체화

2. 면접 결과에서 지원자 상세 보기
        - 총점과 순위와 키워드, 모든 한줄평 조회

3. 새로운 지원자 추가 페이지
       - 지원자 정보 입력(포트폴리오, interviewer 제외->기획 확정 후 진행)
       - 사전 질문 작성 및 댓글 추가

## To Reviewer 💬

https://github.com/team-gotcha/gotcha-server/issues/1#issuecomment-1887399670 
DB 변경사항에 따라 Oneliner, Evaluation 생성 DB 변경사항에 맞게 수정해야돼서 제가 일단 해뒀는데 잘 되었는지 체크 함 해주세요!
https://github.com/team-gotcha/gotcha-server/pull/11/commits/8cb83b53f169e950ec4604b47b4176a2c0a91ec9
이 커밋도 참고해주세용!
@Transactional 관련 어노테이션은 추후에 추가할 예정입니다.
월요일까지 대략적으로 개발 마무리하고 배포하는 건 어떤가요?(-> 그렇다면 Script 작성 필요) 아니면 실시간까지 하고 배포?! 실시간 기능 구현이 얼마나 걸릴지 모르겠네요 🤣