### PR TITLE
자체 Access token과 Refresh token 발급 과정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,11 @@ dependencies {
 	// security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 
+	// jwt
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
+
 	// lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/gotcha/server/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/gotcha/server/applicant/controller/ApplicantController.java
@@ -6,7 +6,7 @@ import com.gotcha.server.applicant.dto.request.InterviewProceedRequest;
 import com.gotcha.server.applicant.dto.request.PassEmailSendRequest;
 import com.gotcha.server.applicant.dto.response.*;
 import com.gotcha.server.applicant.service.ApplicantService;
-import com.gotcha.server.auth.security.MemberDetails;
+import com.gotcha.server.auth.dto.request.MemberDetails;
 
 import io.swagger.v3.oas.annotations.Operation;
 import java.io.IOException;

--- a/src/main/java/com/gotcha/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/gotcha/server/applicant/service/ApplicantService.java
@@ -12,7 +12,7 @@ import com.gotcha.server.applicant.dto.request.*;
 import com.gotcha.server.applicant.dto.response.*;
 import com.gotcha.server.applicant.repository.ApplicantRepository;
 import com.gotcha.server.applicant.repository.KeywordRepository;
-import com.gotcha.server.auth.security.MemberDetails;
+import com.gotcha.server.auth.dto.request.MemberDetails;
 import com.gotcha.server.evaluation.dto.response.OneLinerResponse;
 import com.gotcha.server.evaluation.repository.OneLinerRepository;
 import com.gotcha.server.global.exception.AppException;

--- a/src/main/java/com/gotcha/server/auth/config/SecurityConfig.java
+++ b/src/main/java/com/gotcha/server/auth/config/SecurityConfig.java
@@ -1,6 +1,6 @@
 package com.gotcha.server.auth.config;
 
-import com.gotcha.server.auth.oauth.GoogleAuthenticationFilter;
+import com.gotcha.server.auth.infra.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,7 +20,7 @@ import java.util.Collections;
 @Configuration
 @RequiredArgsConstructor
 public class SecurityConfig {
-    private final GoogleAuthenticationFilter googleAuthenticationFilter;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -38,7 +38,7 @@ public class SecurityConfig {
                         .anyRequest().permitAll()
                 );
 
-        http.addFilterBefore(googleAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/gotcha/server/auth/config/SecurityConfig.java
+++ b/src/main/java/com/gotcha/server/auth/config/SecurityConfig.java
@@ -1,4 +1,4 @@
-package com.gotcha.server.auth.security;
+package com.gotcha.server.auth.config;
 
 import com.gotcha.server.auth.oauth.GoogleAuthenticationFilter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/gotcha/server/auth/controller/AuthorizationResolver.java
+++ b/src/main/java/com/gotcha/server/auth/controller/AuthorizationResolver.java
@@ -1,0 +1,38 @@
+package com.gotcha.server.auth.controller;
+
+import com.gotcha.server.auth.service.JwtTokenProvider;
+import com.gotcha.server.auth.service.MemberDetailsService;
+import com.gotcha.server.global.exception.AppException;
+import com.gotcha.server.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AuthorizationResolver {
+    private static final String BEARER = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MemberDetailsService memberDetailsService;
+
+    public Authentication resolve(final String headerValue) {
+        validateAuthorizationHeader(headerValue);
+        String token = extractToken(headerValue);
+        jwtTokenProvider.validateToken(token);
+        UserDetails userDetails = memberDetailsService.loadUserByUsername(jwtTokenProvider.getPayload(token));
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    private String extractToken(final String headerValue) {
+        return headerValue.substring(BEARER.length()).trim();
+    }
+
+    private void validateAuthorizationHeader(final String headerValue) {
+        if (!headerValue.toLowerCase().startsWith(BEARER.toLowerCase())) {
+            throw new AppException(ErrorCode.INVALID_AUTHORIZATION_HEADER);
+        }
+    }
+}

--- a/src/main/java/com/gotcha/server/auth/dto/request/MemberDetails.java
+++ b/src/main/java/com/gotcha/server/auth/dto/request/MemberDetails.java
@@ -1,4 +1,4 @@
-package com.gotcha.server.auth.security;
+package com.gotcha.server.auth.dto.request;
 
 import com.gotcha.server.member.domain.Member;
 import java.util.ArrayList;

--- a/src/main/java/com/gotcha/server/auth/dto/response/GoogleTokenResponse.java
+++ b/src/main/java/com/gotcha/server/auth/dto/response/GoogleTokenResponse.java
@@ -1,10 +1,4 @@
 package com.gotcha.server.auth.dto.response;
 
-import com.gotcha.server.member.dto.response.LoginResponse;
-
-public record GoogleTokenResponse(
-        String access_token, Integer expires_in, String refresh_token, String scope, String token_type, String id_token) {
-    public LoginResponse toLoginResponse(Long userId) {
-        return new LoginResponse(userId, access_token, refresh_token);
-    }
+public record GoogleTokenResponse(String access_token, Integer expires_in, String scope, String token_type, String id_token) {
 }

--- a/src/main/java/com/gotcha/server/auth/dto/response/GoogleUserResponse.java
+++ b/src/main/java/com/gotcha/server/auth/dto/response/GoogleUserResponse.java
@@ -3,13 +3,12 @@ package com.gotcha.server.auth.dto.response;
 import com.gotcha.server.member.domain.Member;
 
 public record GoogleUserResponse(String sub, String email, String name, String picture) {
-    public Member toEntity(String refreshToken) {
+    public Member toEntity() {
         return Member.builder()
                 .socialId(sub)
                 .email(email)
                 .name(name)
                 .profileUrl(picture)
-                .refreshToken(refreshToken)
                 .build();
     }
 }

--- a/src/main/java/com/gotcha/server/auth/dto/response/RefreshTokenResponse.java
+++ b/src/main/java/com/gotcha/server/auth/dto/response/RefreshTokenResponse.java
@@ -1,5 +1,4 @@
 package com.gotcha.server.auth.dto.response;
 
-public record RefreshTokenResponse(String access_token, int expires_in) {
-
+public record RefreshTokenResponse(String access_token) {
 }

--- a/src/main/java/com/gotcha/server/auth/dto/response/TokenInfoResponse.java
+++ b/src/main/java/com/gotcha/server/auth/dto/response/TokenInfoResponse.java
@@ -1,7 +1,0 @@
-package com.gotcha.server.auth.dto.response;
-
-public record TokenInfoResponse(String sub, String email) {
-    public String socialId() {
-        return sub;
-    }
-}

--- a/src/main/java/com/gotcha/server/auth/oauth/GoogleOAuth.java
+++ b/src/main/java/com/gotcha/server/auth/oauth/GoogleOAuth.java
@@ -4,7 +4,7 @@ import com.gotcha.server.auth.dto.response.GoogleTokenResponse;
 import com.gotcha.server.auth.dto.response.GoogleUserResponse;
 import com.gotcha.server.auth.dto.response.RefreshTokenResponse;
 import com.gotcha.server.auth.dto.response.TokenInfoResponse;
-import com.gotcha.server.auth.security.MemberDetailsService;
+import com.gotcha.server.auth.service.MemberDetailsService;
 import com.gotcha.server.global.exception.AppException;
 import com.gotcha.server.global.exception.ErrorCode;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/gotcha/server/auth/oauth/GoogleOAuth.java
+++ b/src/main/java/com/gotcha/server/auth/oauth/GoogleOAuth.java
@@ -33,7 +33,7 @@ public class GoogleOAuth {
                 .bodyValue(params)
                 .retrieve()
                 .onStatus(status -> status.is4xxClientError(), response -> {
-                    throw new AppException(ErrorCode.INVALID_TOKEN_REQUEST);
+                    throw new AppException(ErrorCode.INVALID_GOOGLE_TOKEN_REQUEST);
                 })
                 .bodyToMono(GoogleTokenResponse.class)
                 .block();

--- a/src/main/java/com/gotcha/server/auth/oauth/GoogleOAuth.java
+++ b/src/main/java/com/gotcha/server/auth/oauth/GoogleOAuth.java
@@ -2,19 +2,12 @@ package com.gotcha.server.auth.oauth;
 
 import com.gotcha.server.auth.dto.response.GoogleTokenResponse;
 import com.gotcha.server.auth.dto.response.GoogleUserResponse;
-import com.gotcha.server.auth.dto.response.RefreshTokenResponse;
-import com.gotcha.server.auth.dto.response.TokenInfoResponse;
-import com.gotcha.server.auth.service.MemberDetailsService;
 import com.gotcha.server.global.exception.AppException;
 import com.gotcha.server.global.exception.ErrorCode;
-import jakarta.servlet.http.HttpServletRequest;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -30,15 +23,7 @@ public class GoogleOAuth {
     @Value("${oauth.google.client-secret}")
     private String CLIENT_SECRET;
 
-    @Value("${oauth.google.scope}")
-    private String DATA_SCOPE;
-
     private final WebClient webClient;
-    private final MemberDetailsService memberDetailsService;
-
-    public String getLoginUrl() {
-        return GoogleUri.LOGIN.getUri(REDIRECT_URI, CLIENT_ID, DATA_SCOPE);
-    }
 
     public GoogleTokenResponse requestTokens(String code) {
         Map<String, Object> params = GoogleUri.getTokenRequestParams(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI, code);
@@ -54,19 +39,6 @@ public class GoogleOAuth {
                 .block();
     }
 
-    public RefreshTokenResponse requestRefresh(String refreshToken) {
-        Map<String, Object> params = GoogleUri.getRefreshRequestParams(CLIENT_ID, CLIENT_SECRET, refreshToken);
-        return webClient.post()
-                .uri(GoogleUri.TOKEN_REQUEST.getUri()).accept(MediaType.APPLICATION_JSON)
-                .bodyValue(params)
-                .retrieve()
-                .onStatus(status -> status.is4xxClientError(), response -> {
-                    throw new AppException(ErrorCode.INVALID_REFRESH_TOKEN);
-                })
-                .bodyToMono(RefreshTokenResponse.class)
-                .block();
-    }
-
     public GoogleUserResponse requestUserInfo(GoogleTokenResponse tokenResponse) {
         return webClient.get()
                 .uri(uriBuilder -> uriBuilder
@@ -79,28 +51,5 @@ public class GoogleOAuth {
                 })
                 .bodyToMono(GoogleUserResponse.class)
                 .block();
-    }
-
-    public TokenInfoResponse requestTokenInfo(String accessToken) {
-        return webClient.get()
-                .uri(uriBuilder -> uriBuilder
-                        .path(GoogleUri.TOKEN_INFO_REQUEST.getUri())
-                        .queryParam("access_token", accessToken)
-                        .build())
-                .retrieve()
-                .onStatus(status -> status.is4xxClientError(), response -> {
-                    throw new AppException(ErrorCode.INVALID_ACCESS_TOKEN);
-                })
-                .bodyToMono(TokenInfoResponse.class)
-                .block();
-    }
-
-    public String resolveToken(HttpServletRequest request) {
-        return request.getHeader("Authorization");
-    }
-
-    public Authentication getAuthentication(TokenInfoResponse tokenInfo) {
-        UserDetails userDetails = memberDetailsService.loadUserByUsername(tokenInfo.socialId());
-        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
 }

--- a/src/main/java/com/gotcha/server/auth/oauth/GoogleUri.java
+++ b/src/main/java/com/gotcha/server/auth/oauth/GoogleUri.java
@@ -1,10 +1,8 @@
 package com.gotcha.server.auth.oauth;
 
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public enum GoogleUri {
-    LOGIN("https://accounts.google.com/o/oauth2/v2/auth"),
     TOKEN_REQUEST("token"),
     TOKEN_INFO_REQUEST("tokeninfo");
 
@@ -14,29 +12,6 @@ public enum GoogleUri {
         this.uri = uri;
     }
 
-    /* LOGIN */
-    public String getUri(final String redirectUri, final String clientId, final String scope) {
-        Map<String,String> params = getLoginParams(redirectUri, clientId, scope);
-        String paramsString = params.entrySet().stream()
-                .map(x -> x.getKey() + "=" + x.getValue())
-                .collect(Collectors.joining("&"));
-        return uri + "?" + paramsString;
-    }
-
-    private Map<String, String> getLoginParams(
-            final String redirectUri, final String clientId, final String scope) {
-        return Map.of(
-                "redirect_uri", redirectUri,
-                "client_id", clientId,
-                "scope", scope,
-                "access_type", "offline",
-                "include_granted_scopes", "true",
-                "state", "state_parameter_passthrough_value",
-                "response_type", "code"
-        );
-    }
-
-    /* TOKEN_REQUEST */
     public String getUri() {
         return uri;
     }
@@ -49,16 +24,6 @@ public enum GoogleUri {
                 "redirect_uri", redirectUri,
                 "code", code,
                 "grant_type", "authorization_code"
-        );
-    }
-
-    public static Map<String, Object> getRefreshRequestParams(
-            final String clientId, final String clientSecret, final String refreshToken) {
-        return Map.of(
-                "client_id", clientId,
-                "client_secret", clientSecret,
-                "refresh_token", refreshToken,
-                "grant_type", "refresh_token"
         );
     }
 }

--- a/src/main/java/com/gotcha/server/auth/service/JwtTokenProvider.java
+++ b/src/main/java/com/gotcha/server/auth/service/JwtTokenProvider.java
@@ -1,0 +1,80 @@
+package com.gotcha.server.auth.service;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProvider {
+    private final Key key;
+    private final long accessTokenValidityInMilliseconds;
+    private final long refreshTokenValidityInMilliseconds;
+
+    public JwtTokenProvider(
+            @Value("${jwt.secret}") final String secret,
+            @Value("${jwt.access-token-validity}") final long accessTokenValidityInMilliseconds,
+            @Value("${jwt.refresh-token-validity}") final long refreshTokenValidityInMilliseconds) {
+        this.key = decodeSecretKey(secret);
+        this.accessTokenValidityInMilliseconds = accessTokenValidityInMilliseconds;
+        this.refreshTokenValidityInMilliseconds = refreshTokenValidityInMilliseconds;
+    }
+
+    private Key decodeSecretKey(final String secret) {
+        byte[] keyBytes = Decoders.BASE64.decode(secret);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String createAccessToken(final String payload) {
+        return createToken(payload, accessTokenValidityInMilliseconds);
+    }
+
+    public String createRefreshToken(final String payload) {
+        return createToken(payload, refreshTokenValidityInMilliseconds);
+    }
+
+    private String createToken(final String payload, final long validityInMilliseconds) {
+        Claims claims = Jwts.claims().setSubject(payload);
+
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + validityInMilliseconds);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setExpiration(validity)
+                .signWith(SignatureAlgorithm.HS256, key)
+                .compact();
+    }
+
+    public String getPayload(final String token) {
+        return Jwts.parser()
+                .setSigningKey(key)
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+
+    public boolean validateToken(String jwtToken) {
+        try {
+            Jwts.parser().setSigningKey(key).parseClaimsJws(jwtToken).getBody();
+            return true;
+        } catch (MalformedJwtException e) {
+            throw new MalformedJwtException("잘못된 JWT 서명입니다.");
+        } catch (ExpiredJwtException e) {
+            throw new JwtException("만료된 JWT 토큰입니다.");
+        } catch (UnsupportedJwtException e) {
+            throw new UnsupportedJwtException("지원되지 않는 JWT 토큰입니다.");
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("JWT 토큰이 잘못되었습니다.");
+        }
+    }
+}

--- a/src/main/java/com/gotcha/server/auth/service/JwtTokenProvider.java
+++ b/src/main/java/com/gotcha/server/auth/service/JwtTokenProvider.java
@@ -1,5 +1,7 @@
 package com.gotcha.server.auth.service;
 
+import com.gotcha.server.global.exception.AppException;
+import com.gotcha.server.global.exception.ErrorCode;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
@@ -68,13 +70,13 @@ public class JwtTokenProvider {
             Jwts.parser().setSigningKey(key).parseClaimsJws(jwtToken).getBody();
             return true;
         } catch (MalformedJwtException e) {
-            throw new MalformedJwtException("잘못된 JWT 서명입니다.");
+            throw new AppException(ErrorCode.MALFORMED_JWT);
         } catch (ExpiredJwtException e) {
-            throw new JwtException("만료된 JWT 토큰입니다.");
+            throw new AppException(ErrorCode.EXPIRED_JWT);
         } catch (UnsupportedJwtException e) {
-            throw new UnsupportedJwtException("지원되지 않는 JWT 토큰입니다.");
+            throw new AppException(ErrorCode.UNSUPPORTED_JWT);
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("JWT 토큰이 잘못되었습니다.");
+            throw new AppException(ErrorCode.INVALID_JWT);
         }
     }
 }

--- a/src/main/java/com/gotcha/server/auth/service/MemberDetailsService.java
+++ b/src/main/java/com/gotcha/server/auth/service/MemberDetailsService.java
@@ -1,5 +1,6 @@
-package com.gotcha.server.auth.security;
+package com.gotcha.server.auth.service;
 
+import com.gotcha.server.auth.dto.request.MemberDetails;
 import com.gotcha.server.global.exception.AppException;
 import com.gotcha.server.global.exception.ErrorCode;
 import com.gotcha.server.member.domain.Member;

--- a/src/main/java/com/gotcha/server/evaluation/controller/EvaluationController.java
+++ b/src/main/java/com/gotcha/server/evaluation/controller/EvaluationController.java
@@ -1,6 +1,6 @@
 package com.gotcha.server.evaluation.controller;
 
-import com.gotcha.server.auth.security.MemberDetails;
+import com.gotcha.server.auth.dto.request.MemberDetails;
 import com.gotcha.server.evaluation.dto.request.EvaluateRequest;
 import com.gotcha.server.evaluation.dto.request.OneLinerRequest;
 import com.gotcha.server.evaluation.dto.response.QuestionEvaluationResponse;

--- a/src/main/java/com/gotcha/server/evaluation/service/EvaluationService.java
+++ b/src/main/java/com/gotcha/server/evaluation/service/EvaluationService.java
@@ -3,7 +3,7 @@ package com.gotcha.server.evaluation.service;
 import com.gotcha.server.applicant.domain.Applicant;
 import com.gotcha.server.applicant.domain.InterviewStatus;
 import com.gotcha.server.applicant.repository.ApplicantRepository;
-import com.gotcha.server.auth.security.MemberDetails;
+import com.gotcha.server.auth.dto.request.MemberDetails;
 import com.gotcha.server.evaluation.domain.Evaluation;
 import com.gotcha.server.evaluation.domain.OneLiner;
 import com.gotcha.server.evaluation.dto.request.EvaluateRequest;

--- a/src/main/java/com/gotcha/server/global/config/OpenApiConfig.java
+++ b/src/main/java/com/gotcha/server/global/config/OpenApiConfig.java
@@ -1,27 +1,37 @@
 package com.gotcha.server.global.config;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class OpenApiConfig {
+    private final String deployedUrl;
 
-    private static final String SECURITY_SCHEME_NAME = "authorization";
+    public OpenApiConfig(@Value("${deployed-url}") final String url) {
+        this.deployedUrl = url;
+    }
 
     @Bean
     public OpenAPI swaggerApi() {
         return new OpenAPI()
                 .components(new Components()
-                        .addSecuritySchemes(SECURITY_SCHEME_NAME, new SecurityScheme()
-                                .name(SECURITY_SCHEME_NAME)
+                        .addSecuritySchemes(AUTHORIZATION, new SecurityScheme()
+                                .name(AUTHORIZATION)
                                 .type(SecurityScheme.Type.HTTP)
                                 .scheme("bearer")
                                 .bearerFormat("JWT")))
-                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
+                .addSecurityItem(new SecurityRequirement().addList(AUTHORIZATION))
+                .servers(List.of(new Server().url(deployedUrl)))
                 .info(new Info()
                         .title("API Document")
                         .version("v1")

--- a/src/main/java/com/gotcha/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/gotcha/server/global/exception/ErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "존재하지 않는 사용자입니다."),
+    INVALID_AUTHORIZATION_HEADER(HttpStatus.UNAUTHORIZED, "유효하지 않은 Authorization 헤더 형식입니다."),
     INVALID_TOKEN_REQUEST(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰 요청 입니다."),
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 access token 입니다."),
     INVALID_ID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 id token 입니다."),

--- a/src/main/java/com/gotcha/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/gotcha/server/global/exception/ErrorCode.java
@@ -9,12 +9,12 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "존재하지 않는 사용자입니다."),
     INVALID_AUTHORIZATION_HEADER(HttpStatus.UNAUTHORIZED, "유효하지 않은 Authorization 헤더 형식입니다."),
-    INVALID_GOOGLE_TOKEN_REQUEST(HttpStatus.UNAUTHORIZED, "유효하지 않은 구글 토큰 요청 입니다."),
+    INVALID_GOOGLE_TOKEN_REQUEST(HttpStatus.UNAUTHORIZED, "유효하지 않은 구글 토큰 요청입니다."),
     MALFORMED_JWT(HttpStatus.UNAUTHORIZED, "잘못된 JWT 서명입니다."),
     EXPIRED_JWT(HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다."),
     UNSUPPORTED_JWT(HttpStatus.UNAUTHORIZED, "지원되지 않는 JWT 토큰입니다."),
     INVALID_JWT(HttpStatus.UNAUTHORIZED, "JWT 토큰이 잘못되었습니다."),
-    INVALID_ID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 id token 입니다."),
+    INVALID_ID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 구글 id 토큰입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 refresh token 입니다."),
     UNAUTHORIZED_INTERVIEWER(HttpStatus.UNAUTHORIZED, "면접관 권한이 없습니다."),
 

--- a/src/main/java/com/gotcha/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/gotcha/server/global/exception/ErrorCode.java
@@ -9,8 +9,11 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "존재하지 않는 사용자입니다."),
     INVALID_AUTHORIZATION_HEADER(HttpStatus.UNAUTHORIZED, "유효하지 않은 Authorization 헤더 형식입니다."),
-    INVALID_TOKEN_REQUEST(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰 요청 입니다."),
-    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 access token 입니다."),
+    INVALID_GOOGLE_TOKEN_REQUEST(HttpStatus.UNAUTHORIZED, "유효하지 않은 구글 토큰 요청 입니다."),
+    MALFORMED_JWT(HttpStatus.UNAUTHORIZED, "잘못된 JWT 서명입니다."),
+    EXPIRED_JWT(HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다."),
+    UNSUPPORTED_JWT(HttpStatus.UNAUTHORIZED, "지원되지 않는 JWT 토큰입니다."),
+    INVALID_JWT(HttpStatus.UNAUTHORIZED, "JWT 토큰이 잘못되었습니다."),
     INVALID_ID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 id token 입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 refresh token 입니다."),
     UNAUTHORIZED_INTERVIEWER(HttpStatus.UNAUTHORIZED, "면접관 권한이 없습니다."),

--- a/src/main/java/com/gotcha/server/member/controller/MemberController.java
+++ b/src/main/java/com/gotcha/server/member/controller/MemberController.java
@@ -33,10 +33,17 @@ public class MemberController {
         return ResponseEntity.ok(memberService.refresh(request));
     }
 
-    @GetMapping("/todays-interview")
+    @GetMapping("/api/todays-interview")
     @Operation(description = "로그인한 유저의 오늘 예정된 면접 수를 조회한다.")
     public ResponseEntity<TodayInterviewResponse> countInterview(@AuthenticationPrincipal final MemberDetails details) {
         return ResponseEntity.ok(memberService.countTodayInterview(details));
+    }
+
+    @PostMapping("/api/logout")
+    @Operation(description = "로그아웃한다.")
+    public ResponseEntity<Void> logout(@AuthenticationPrincipal final MemberDetails details) {
+        memberService.logout(details);
+        return ResponseEntity.ok().build();
     }
 
     @GetMapping("/")

--- a/src/main/java/com/gotcha/server/member/controller/MemberController.java
+++ b/src/main/java/com/gotcha/server/member/controller/MemberController.java
@@ -5,7 +5,6 @@ import com.gotcha.server.auth.dto.response.RefreshTokenResponse;
 import com.gotcha.server.auth.dto.request.MemberDetails;
 import com.gotcha.server.member.dto.response.LoginResponse;
 import com.gotcha.server.member.dto.request.RefreshTokenRequest;
-import com.gotcha.server.member.dto.response.UserResponse;
 import com.gotcha.server.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -23,12 +22,6 @@ public class MemberController {
     private final MemberService memberService;
 
     @GetMapping("/api/login/google")
-    @Operation(description = "구글 소셜 로그인 url을 받는다.")
-    public ResponseEntity<String> redirectGoogleLogin(){
-        return ResponseEntity.ok(memberService.getLoginUrl());
-    }
-
-    @GetMapping("/api/google/token")
     @Operation(description = "access token과 refresh token을 발급 받는다. 회원가입 되지 않은 유저라면 가입한다.")
     public ResponseEntity<LoginResponse> getGoogleToken(@RequestParam String code) {
         return ResponseEntity.ok(memberService.login(code));
@@ -38,12 +31,6 @@ public class MemberController {
     @Operation(description = "access token을 재발급 받는다.")
     public ResponseEntity<RefreshTokenResponse> refreshToken(@RequestBody RefreshTokenRequest request) {
         return ResponseEntity.ok(memberService.refresh(request));
-    }
-
-    @GetMapping("/api/user")
-    @Operation(description = "로그인 유저의 개인 정보를 조회한다.")
-    public ResponseEntity<UserResponse> getUserDetails(@AuthenticationPrincipal final MemberDetails details) {
-        return ResponseEntity.ok(memberService.getUserDetails(details));
     }
 
     @GetMapping("/todays-interview")

--- a/src/main/java/com/gotcha/server/member/controller/MemberController.java
+++ b/src/main/java/com/gotcha/server/member/controller/MemberController.java
@@ -2,7 +2,7 @@ package com.gotcha.server.member.controller;
 
 import com.gotcha.server.member.dto.response.TodayInterviewResponse;
 import com.gotcha.server.auth.dto.response.RefreshTokenResponse;
-import com.gotcha.server.auth.security.MemberDetails;
+import com.gotcha.server.auth.dto.request.MemberDetails;
 import com.gotcha.server.member.dto.response.LoginResponse;
 import com.gotcha.server.member.dto.request.RefreshTokenRequest;
 import com.gotcha.server.member.dto.response.UserResponse;

--- a/src/main/java/com/gotcha/server/member/domain/Member.java
+++ b/src/main/java/com/gotcha/server/member/domain/Member.java
@@ -24,7 +24,7 @@ public class Member extends BaseTimeEntity {
     @Column(nullable = false)
     private String socialId;
 
-    @Column(nullable = false)
+    @Column
     private String email;
 
     @Column(nullable = false)

--- a/src/main/java/com/gotcha/server/member/domain/Member.java
+++ b/src/main/java/com/gotcha/server/member/domain/Member.java
@@ -51,4 +51,8 @@ public class Member extends BaseTimeEntity {
         this.refreshToken = refreshToken;
         this.role = Role.ROLE_USER;
     }
+
+    public void updateRefreshToken(final String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
 }

--- a/src/main/java/com/gotcha/server/member/dto/request/RefreshTokenRequest.java
+++ b/src/main/java/com/gotcha/server/member/dto/request/RefreshTokenRequest.java
@@ -1,5 +1,4 @@
 package com.gotcha.server.member.dto.request;
 
-public record RefreshTokenRequest(Long userId) {
-
+public record RefreshTokenRequest(String refreshToken) {
 }

--- a/src/main/java/com/gotcha/server/member/dto/response/LoginResponse.java
+++ b/src/main/java/com/gotcha/server/member/dto/response/LoginResponse.java
@@ -1,5 +1,5 @@
 package com.gotcha.server.member.dto.response;
 
-public record LoginResponse(Long userId, String accessToken, String refreshToken) {
+public record LoginResponse(Long userId, String accessToken, String refreshToken, String email) {
 
 }

--- a/src/main/java/com/gotcha/server/member/dto/response/UserResponse.java
+++ b/src/main/java/com/gotcha/server/member/dto/response/UserResponse.java
@@ -1,5 +1,0 @@
-package com.gotcha.server.member.dto.response;
-
-public record UserResponse(String profileImage, String name, String email) {
-
-}

--- a/src/main/java/com/gotcha/server/member/repository/MemberRepository.java
+++ b/src/main/java/com/gotcha/server/member/repository/MemberRepository.java
@@ -6,7 +6,7 @@ import com.gotcha.server.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByEmail(String email);
+    Optional<Member> findBySocialIdAndRefreshToken(String socialId, String refreshToken);
 
     Optional<Member> findBySocialId(String socialId);
 }

--- a/src/main/java/com/gotcha/server/member/service/MemberService.java
+++ b/src/main/java/com/gotcha/server/member/service/MemberService.java
@@ -52,7 +52,7 @@ public class MemberService {
         String accessToken = jwtTokenProvider.createAccessToken(member.getSocialId());
         String refreshToken = jwtTokenProvider.createRefreshToken(member.getSocialId());
         member.updateRefreshToken(refreshToken);
-        return new LoginResponse(member.getId(), accessToken, refreshToken);
+        return new LoginResponse(member.getId(), accessToken, refreshToken, member.getEmail());
     }
 
     @Transactional

--- a/src/main/java/com/gotcha/server/member/service/MemberService.java
+++ b/src/main/java/com/gotcha/server/member/service/MemberService.java
@@ -4,7 +4,7 @@ import com.gotcha.server.member.dto.response.TodayInterviewResponse;
 import com.gotcha.server.applicant.repository.InterviewerRepository;
 import com.gotcha.server.auth.dto.response.RefreshTokenResponse;
 import com.gotcha.server.auth.oauth.GoogleOAuth;
-import com.gotcha.server.auth.security.MemberDetails;
+import com.gotcha.server.auth.dto.request.MemberDetails;
 import com.gotcha.server.global.exception.AppException;
 import com.gotcha.server.global.exception.ErrorCode;
 import com.gotcha.server.member.domain.Member;

--- a/src/main/java/com/gotcha/server/member/service/MemberService.java
+++ b/src/main/java/com/gotcha/server/member/service/MemberService.java
@@ -55,6 +55,13 @@ public class MemberService {
         return new LoginResponse(member.getId(), accessToken, refreshToken);
     }
 
+    @Transactional
+    public void logout(final MemberDetails details) {
+        Member member = details.member();
+        member.updateRefreshToken(null);
+        memberRepository.save(member);
+    }
+
     public TodayInterviewResponse countTodayInterview(final MemberDetails details) {
         long count = interviewerRepository.countTodayInterview(details.member());
         return new TodayInterviewResponse(count);

--- a/src/main/java/com/gotcha/server/project/controller/ProjectController.java
+++ b/src/main/java/com/gotcha/server/project/controller/ProjectController.java
@@ -1,9 +1,6 @@
 package com.gotcha.server.project.controller;
 
-import com.gotcha.server.auth.security.MemberDetails;
-import com.gotcha.server.member.domain.Member;
-import com.gotcha.server.member.domain.Role;
-import com.gotcha.server.project.domain.Collaborator;
+import com.gotcha.server.auth.dto.request.MemberDetails;
 import com.gotcha.server.project.dto.request.ProjectRequest;
 import com.gotcha.server.project.dto.response.ProjectResponse;
 import com.gotcha.server.project.dto.response.SidebarResponse;

--- a/src/main/java/com/gotcha/server/question/controller/QuestionController.java
+++ b/src/main/java/com/gotcha/server/question/controller/QuestionController.java
@@ -25,7 +25,7 @@ public class QuestionController {
 
     @PostMapping("/common")
     @Operation(description = "공통 질문을 생성한다.")
-    public ResponseEntity<Void> createCommonQuestions(final CommonQuestionsRequest request) {
+    public ResponseEntity<Void> createCommonQuestions(@RequestBody final CommonQuestionsRequest request) {
         questionService.createCommonQuestions(request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }

--- a/src/main/java/com/gotcha/server/question/controller/QuestionController.java
+++ b/src/main/java/com/gotcha/server/question/controller/QuestionController.java
@@ -2,7 +2,7 @@ package com.gotcha.server.question.controller;
 
 import com.gotcha.server.question.dto.response.QuestionRankResponse;
 import com.gotcha.server.question.dto.request.IndividualQuestionRequest;
-import com.gotcha.server.auth.security.MemberDetails;
+import com.gotcha.server.auth.dto.request.MemberDetails;
 import com.gotcha.server.question.dto.request.CommonQuestionsRequest;
 import com.gotcha.server.question.dto.response.InterviewQuestionResponse;
 import com.gotcha.server.question.dto.response.PreparatoryQuestionResponse;

--- a/src/test/java/com/gotcha/server/applicant/service/ApplicantServiceTest.java
+++ b/src/test/java/com/gotcha/server/applicant/service/ApplicantServiceTest.java
@@ -10,7 +10,7 @@ import com.gotcha.server.applicant.dto.request.GoQuestionPublicRequest;
 import com.gotcha.server.applicant.dto.request.InterviewProceedRequest;
 import com.gotcha.server.applicant.dto.response.ApplicantResponse;
 import com.gotcha.server.applicant.repository.ApplicantRepository;
-import com.gotcha.server.auth.security.MemberDetails;
+import com.gotcha.server.auth.dto.request.MemberDetails;
 import com.gotcha.server.common.IntegrationTest;
 import com.gotcha.server.member.domain.Member;
 import com.gotcha.server.project.domain.Interview;

--- a/src/test/java/com/gotcha/server/evaluation/service/EvaluationServiceTest.java
+++ b/src/test/java/com/gotcha/server/evaluation/service/EvaluationServiceTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.gotcha.server.applicant.domain.Applicant;
 import com.gotcha.server.applicant.domain.Interviewer;
-import com.gotcha.server.auth.security.MemberDetails;
+import com.gotcha.server.auth.dto.request.MemberDetails;
 import com.gotcha.server.common.IntegrationTest;
 import com.gotcha.server.evaluation.domain.Evaluation;
 import com.gotcha.server.evaluation.dto.request.EvaluateRequest;


### PR DESCRIPTION
## Check 🌈

- [x] 배포 브랜치에 바로 merge합니다.
- [x] merge는 PR 작성자가 합니다

## Description 📒

>기존에는 구글이 제공하는 토큰을 사용했지만, api fetching하고 e2e 테스트하면서 문제가 많아 수정하였습니다.
>그리고 구글이 jwt 토큰을 제공하는 걸로 알아서, access token과 refresh token이 jwt인줄 알았지만, 찾아보니 아니였습니다.. (다른 token이 jwt였음) 
>1. 인증 권한 한 번만 로그인할 때 구글에서 받고, 자체 jwt 토큰 생성하는 식으로 변경했습니다.
>2. 패키지 구조 리팩토링했습니다.
>3. swagger에 배포 https url을 반영했습니다.
