### PR TITLE
웹소켓 통신 인증, 개별 질문 목록 조회 기능 구현 및 오류 수정

### DIFF
--- a/src/main/java/com/gotcha/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/gotcha/server/applicant/service/ApplicantService.java
@@ -199,9 +199,23 @@ public class ApplicantService {
     }
 
     public List<IndividualQuestion> createIndividualQuestions(List<IndividualQuestionRequest> questionRequests, Member member) {
-        return questionRequests.stream()
-                .map(request -> request.toEntity(member, applicantRepository, individualQuestionRepository))
-                .collect(Collectors.toList());
+        List<IndividualQuestion> individualQuestions = new ArrayList<>();
+        for(IndividualQuestionRequest request: questionRequests) {
+            Applicant applicant = applicantRepository.findById(request.getApplicantId())
+                .orElseThrow(() -> new AppException(ErrorCode.APPLICANT_NOT_FOUNT));
+            IndividualQuestion individualQuestion = findCommentTarget(request.getCommentTargetId());
+            IndividualQuestion question = request.toEntity(member, applicant, individualQuestion);
+            individualQuestions.add(question);
+        }
+        return individualQuestions;
+    }
+
+    private IndividualQuestion findCommentTarget(final Long id) {
+        if(Objects.isNull(id)) {
+            return null;
+        }
+        return individualQuestionRepository.findById(id)
+                .orElseThrow(() -> new AppException(ErrorCode.QUESTION_NOT_FOUNT));
     }
 
     public List<Interviewer> createInterviewers(List<InterviewerRequest> interviewerRequests) {

--- a/src/main/java/com/gotcha/server/auth/controller/AuthorizationResolver.java
+++ b/src/main/java/com/gotcha/server/auth/controller/AuthorizationResolver.java
@@ -18,12 +18,17 @@ public class AuthorizationResolver {
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberDetailsService memberDetailsService;
 
-    public Authentication resolve(final String headerValue) {
+    public Authentication resolveAuthentication(final String headerValue) {
+        String token = resolveToken(headerValue);
+        UserDetails userDetails = memberDetailsService.loadUserByUsername(jwtTokenProvider.getPayload(token));
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    public String resolveToken(final String headerValue) {
         validateAuthorizationHeader(headerValue);
         String token = extractToken(headerValue);
         jwtTokenProvider.validateToken(token);
-        UserDetails userDetails = memberDetailsService.loadUserByUsername(jwtTokenProvider.getPayload(token));
-        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+        return token;
     }
 
     private String extractToken(final String headerValue) {

--- a/src/main/java/com/gotcha/server/auth/infra/JwtAuthenticationFilter.java
+++ b/src/main/java/com/gotcha/server/auth/infra/JwtAuthenticationFilter.java
@@ -26,7 +26,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         try {
             String authorization = extractAuthorizationHeader(request);
             if (Objects.nonNull(authorization)) {
-                Authentication authentication = authorizationResolver.resolve(authorization);
+                Authentication authentication = authorizationResolver.resolveAuthentication(authorization);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
             filterChain.doFilter(request, response);

--- a/src/main/java/com/gotcha/server/auth/oauth/GoogleOAuth.java
+++ b/src/main/java/com/gotcha/server/auth/oauth/GoogleOAuth.java
@@ -14,9 +14,6 @@ import org.springframework.web.reactive.function.client.WebClient;
 @Component
 @RequiredArgsConstructor
 public class GoogleOAuth {
-    @Value("${oauth.google.redirect-url}")
-    private String REDIRECT_URI;
-
     @Value("${oauth.google.client-id}")
     private String CLIENT_ID;
 
@@ -25,8 +22,8 @@ public class GoogleOAuth {
 
     private final WebClient webClient;
 
-    public GoogleTokenResponse requestTokens(String code) {
-        Map<String, Object> params = GoogleUri.getTokenRequestParams(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI, code);
+    public GoogleTokenResponse requestTokens(String code, String redirectUri) {
+        Map<String, Object> params = GoogleUri.getTokenRequestParams(CLIENT_ID, CLIENT_SECRET, redirectUri, code);
         return webClient.post()
                 .uri(GoogleUri.TOKEN_REQUEST.getUri())
                 .accept(MediaType.APPLICATION_JSON)

--- a/src/main/java/com/gotcha/server/global/config/WebSocketConfig.java
+++ b/src/main/java/com/gotcha/server/global/config/WebSocketConfig.java
@@ -1,14 +1,20 @@
 package com.gotcha.server.global.config;
 
+import com.gotcha.server.global.interceptor.WebSocketInterceptor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    private final WebSocketInterceptor webSocketInterceptor;
+
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         registry.enableSimpleBroker("/sub");
@@ -20,5 +26,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         registry.addEndpoint("/ws")
                 .setAllowedOrigins("*")
                 .withSockJS();
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration){
+        registration.interceptors(webSocketInterceptor);
     }
 }

--- a/src/main/java/com/gotcha/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/gotcha/server/global/exception/ErrorCode.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
-    USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "존재하지 않는 사용자입니다."),
+    USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "로그인한 사용자가 존재하지 않습니다."),
+    TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다."),
     INVALID_AUTHORIZATION_HEADER(HttpStatus.UNAUTHORIZED, "유효하지 않은 Authorization 헤더 형식입니다."),
     INVALID_GOOGLE_TOKEN_REQUEST(HttpStatus.UNAUTHORIZED, "유효하지 않은 구글 토큰 요청입니다."),
     MALFORMED_JWT(HttpStatus.UNAUTHORIZED, "잘못된 JWT 서명입니다."),

--- a/src/main/java/com/gotcha/server/global/interceptor/WebSocketInterceptor.java
+++ b/src/main/java/com/gotcha/server/global/interceptor/WebSocketInterceptor.java
@@ -1,0 +1,40 @@
+package com.gotcha.server.global.interceptor;
+
+import com.gotcha.server.auth.controller.AuthorizationResolver;
+import com.gotcha.server.global.exception.AppException;
+import com.gotcha.server.global.exception.ErrorCode;
+import java.util.List;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebSocketInterceptor implements ChannelInterceptor {
+    private final AuthorizationResolver authorizationResolver;
+
+    @Override
+    public Message<?> preSend(final Message<?> message, final MessageChannel channel) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+        String headerValue = extractAuthorizationHeader(accessor);
+        if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+            authorizationResolver.resolveToken(headerValue);
+        }
+        return message;
+    }
+
+    private String extractAuthorizationHeader(final StompHeaderAccessor accessor) {
+        List<String> values = accessor.getNativeHeader(StompHeaderAccessor.STOMP_LOGIN_HEADER);
+        if(Objects.isNull(values) || values.size() == 0) {
+            throw new AppException(ErrorCode.TOKEN_NOT_FOUND);
+        }
+        return values.get(0);
+    }
+}

--- a/src/main/java/com/gotcha/server/member/controller/MemberController.java
+++ b/src/main/java/com/gotcha/server/member/controller/MemberController.java
@@ -23,8 +23,8 @@ public class MemberController {
 
     @GetMapping("/api/login/google")
     @Operation(description = "access token과 refresh token을 발급 받는다. 회원가입 되지 않은 유저라면 가입한다.")
-    public ResponseEntity<LoginResponse> getGoogleToken(@RequestParam String code) {
-        return ResponseEntity.ok(memberService.login(code));
+    public ResponseEntity<LoginResponse> getGoogleToken(@RequestParam String code, @RequestParam(value = "redirect-uri") String redirectUri) {
+        return ResponseEntity.ok(memberService.login(code, redirectUri));
     }
 
     @PostMapping("/api/refresh")

--- a/src/main/java/com/gotcha/server/member/service/MemberService.java
+++ b/src/main/java/com/gotcha/server/member/service/MemberService.java
@@ -42,8 +42,8 @@ public class MemberService {
     }
 
     @Transactional
-    public LoginResponse login(String code) {
-        GoogleTokenResponse googleToken = googleOAuth.requestTokens(code);
+    public LoginResponse login(String code, String redirectUri) {
+        GoogleTokenResponse googleToken = googleOAuth.requestTokens(code, redirectUri);
         GoogleUserResponse googleUser = googleOAuth.requestUserInfo(googleToken);
         Member member = memberRepository.findBySocialId(googleUser.sub()).orElse(null);
         if(Objects.isNull(member)) {

--- a/src/main/java/com/gotcha/server/question/controller/QuestionController.java
+++ b/src/main/java/com/gotcha/server/question/controller/QuestionController.java
@@ -1,5 +1,6 @@
 package com.gotcha.server.question.controller;
 
+import com.gotcha.server.question.dto.response.IndividualQuestionsResponse;
 import com.gotcha.server.question.dto.response.QuestionRankResponse;
 import com.gotcha.server.question.dto.request.IndividualQuestionRequest;
 import com.gotcha.server.auth.dto.request.MemberDetails;
@@ -28,6 +29,12 @@ public class QuestionController {
     public ResponseEntity<Void> createCommonQuestions(@RequestBody final CommonQuestionsRequest request) {
         questionService.createCommonQuestions(request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping
+    @Operation(description = "면접 전 지원자의 개별 질문 목록을 조회한다.")
+    public ResponseEntity<List<IndividualQuestionsResponse>> findAllIndividualQuestions(@RequestParam(name = "applicant-id") Long applicantId) {
+        return ResponseEntity.ok(questionService.listIndividualQuestions(applicantId));
     }
 
     @GetMapping("/in-progress")

--- a/src/main/java/com/gotcha/server/question/dto/request/IndividualQuestionRequest.java
+++ b/src/main/java/com/gotcha/server/question/dto/request/IndividualQuestionRequest.java
@@ -1,46 +1,19 @@
 package com.gotcha.server.question.dto.request;
 
 import com.gotcha.server.applicant.domain.Applicant;
-import com.gotcha.server.applicant.domain.Keyword;
-import com.gotcha.server.applicant.domain.KeywordType;
-import com.gotcha.server.applicant.repository.ApplicantRepository;
-import com.gotcha.server.global.exception.AppException;
-import com.gotcha.server.global.exception.ErrorCode;
 import com.gotcha.server.member.domain.Member;
 import com.gotcha.server.question.domain.IndividualQuestion;
-import com.gotcha.server.question.repository.IndividualQuestionRepository;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
 @Getter
 public class IndividualQuestionRequest {
-
     private String content;
     private Long applicantId;
     private Long commentTargetId;
 
-    @Builder
-    public IndividualQuestionRequest(String content, Long applicantId, Long commentTargetId) {
-        this.content = content;
-        this.applicantId = applicantId;
-        this.commentTargetId = commentTargetId;
-    }
-
-    public IndividualQuestion toEntity(Member member, ApplicantRepository applicantRepository, IndividualQuestionRepository individualQuestionRepository){
-        Applicant applicant = null;
-        if (applicantId != null) {
-            applicant = applicantRepository.findById(applicantId)
-                    .orElseThrow(() -> new AppException(ErrorCode.APPLICANT_NOT_FOUNT));
-        }
-
-        IndividualQuestion commentTarget = null;
-        if (commentTargetId != null) {
-            commentTarget = individualQuestionRepository.findById(commentTargetId)
-                    .orElseThrow(() -> new AppException(ErrorCode.QUESTION_NOT_FOUNT));
-        }
-
+    public IndividualQuestion toEntity(Member member, Applicant applicant, IndividualQuestion commentTarget){
         return IndividualQuestion.builder()
                 .content(content)
                 .applicant(applicant)

--- a/src/main/java/com/gotcha/server/question/dto/response/IndividualQuestionsResponse.java
+++ b/src/main/java/com/gotcha/server/question/dto/response/IndividualQuestionsResponse.java
@@ -1,0 +1,39 @@
+package com.gotcha.server.question.dto.response;
+
+import com.gotcha.server.question.domain.IndividualQuestion;
+import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class IndividualQuestionsResponse {
+    private Long id;
+    private String content;
+    private String writerName;
+    private String writerProfile;
+    private Long commentTargetId;
+    private Boolean asking;
+    // Todo: 좋아요 개수 추가
+
+    public static IndividualQuestionsResponse from(final IndividualQuestion individualQuestion) {
+        Long commentTargetId = null;
+        IndividualQuestion commentTarget = individualQuestion.getCommentTarget();
+        if(Objects.nonNull(commentTarget)) {
+            commentTargetId = commentTarget.getId();
+        }
+
+        return IndividualQuestionsResponse.builder()
+                .id(individualQuestion.getId())
+                .content(individualQuestion.getContent())
+                .writerName(individualQuestion.getMember().getName())
+                .writerProfile(individualQuestion.getMember().getProfileUrl())
+                .commentTargetId(commentTargetId)
+                .asking(individualQuestion.isAsking())
+                .build();
+    }
+}

--- a/src/main/java/com/gotcha/server/question/repository/QuestionDslRepository.java
+++ b/src/main/java/com/gotcha/server/question/repository/QuestionDslRepository.java
@@ -5,6 +5,7 @@ import com.gotcha.server.question.domain.IndividualQuestion;
 import java.util.List;
 
 public interface QuestionDslRepository {
+    List<IndividualQuestion> findAllBeforeInterview(Applicant applicant);
     List<IndividualQuestion> findAllDuringInterview(Applicant applicant);
     List<IndividualQuestion> findAllAfterEvaluation(Applicant applicant);
 }

--- a/src/main/java/com/gotcha/server/question/repository/QuestionDslRepositoryImpl.java
+++ b/src/main/java/com/gotcha/server/question/repository/QuestionDslRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.gotcha.server.question.repository;
 
 import com.gotcha.server.applicant.domain.Applicant;
 import com.gotcha.server.evaluation.domain.QEvaluation;
+import com.gotcha.server.member.domain.QMember;
 import com.gotcha.server.question.domain.IndividualQuestion;
 import com.gotcha.server.question.domain.QIndividualQuestion;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -13,6 +14,23 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class QuestionDslRepositoryImpl implements QuestionDslRepository {
     private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<IndividualQuestion> findAllBeforeInterview(Applicant applicant) {
+        QIndividualQuestion qQuestion = QIndividualQuestion.individualQuestion;
+        QIndividualQuestion qCommentTarget = new QIndividualQuestion("commentTarget");
+        QMember qMember = QMember.member;
+
+        return jpaQueryFactory
+                .select(qQuestion)
+                .from(qQuestion)
+                .where(qQuestion.applicant.eq(applicant))
+                .innerJoin(qQuestion.member, qMember)
+                .fetchJoin()
+                .leftJoin(qQuestion.commentTarget, qCommentTarget)
+                .fetchJoin()
+                .fetch();
+    }
 
     @Override
     public List<IndividualQuestion> findAllDuringInterview(Applicant applicant) {

--- a/src/main/java/com/gotcha/server/question/service/QuestionService.java
+++ b/src/main/java/com/gotcha/server/question/service/QuestionService.java
@@ -21,6 +21,7 @@ import com.gotcha.server.question.dto.response.PreparatoryQuestionResponse;
 import com.gotcha.server.question.repository.CommonQuestionRepository;
 import com.gotcha.server.question.repository.IndividualQuestionRepository;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -75,7 +76,10 @@ public class QuestionService {
     public void createIndividualQuestion(IndividualQuestionRequest request, Member member){
         validQuestion(request);
 
-        IndividualQuestion question = request.toEntity(member, applicantRepository, individualQuestionRepository);
+        Applicant applicant = applicantRepository.findById(request.getApplicantId())
+                .orElseThrow(() -> new AppException(ErrorCode.APPLICANT_NOT_FOUNT));
+        IndividualQuestion individualQuestion = findCommentTarget(request.getCommentTargetId());
+        IndividualQuestion question = request.toEntity(member, applicant, individualQuestion);
         individualQuestionRepository.save(question);
     }
 
@@ -83,6 +87,14 @@ public class QuestionService {
         if (request.getContent() == null || request.getContent().trim().isEmpty()) {
             throw new AppException(ErrorCode.CONTENT_IS_EMPTY);
         }
+    }
+
+    private IndividualQuestion findCommentTarget(final Long id) {
+        if(Objects.isNull(id)) {
+            return null;
+        }
+        return individualQuestionRepository.findById(id)
+                .orElseThrow(() -> new AppException(ErrorCode.QUESTION_NOT_FOUNT));
     }
 
     public List<PreparatoryQuestionResponse> listPreparatoryQuestions(final Long applicantId) {

--- a/src/main/java/com/gotcha/server/question/service/QuestionService.java
+++ b/src/main/java/com/gotcha/server/question/service/QuestionService.java
@@ -2,6 +2,7 @@ package com.gotcha.server.question.service;
 
 import com.gotcha.server.applicant.domain.Applicant;
 import com.gotcha.server.evaluation.domain.QuestionEvaluations;
+import com.gotcha.server.question.dto.response.IndividualQuestionsResponse;
 import com.gotcha.server.question.dto.response.QuestionRankResponse;
 import com.gotcha.server.question.domain.QuestionPublicType;
 import com.gotcha.server.question.dto.message.QuestionUpdateMessage;
@@ -44,6 +45,13 @@ public class QuestionService {
                 .map(content -> new CommonQuestion(content, interview))
                 .collect(Collectors.toList());
         commonQuestionRepository.saveAll(questions);
+    }
+
+    public List<IndividualQuestionsResponse> listIndividualQuestions(final Long applicantId) {
+        Applicant applicant = applicantRepository.findById(applicantId)
+                .orElseThrow(() -> new AppException(ErrorCode.APPLICANT_NOT_FOUNT));
+        List<IndividualQuestion> questions = individualQuestionRepository.findAllBeforeInterview(applicant);
+        return questions.stream().map(IndividualQuestionsResponse::from).toList();
     }
 
     @Transactional

--- a/src/test/java/com/gotcha/server/common/IntegrationTestEnviron.java
+++ b/src/test/java/com/gotcha/server/common/IntegrationTestEnviron.java
@@ -66,8 +66,8 @@ public class IntegrationTestEnviron {
         return keywordRepository.save(테스트키워드(지원자, 내용, 종류));
     }
 
-    public IndividualQuestion 테스트개별질문_저장하기(Applicant 지원자, String 내용, Integer 순서, boolean 면접때질문하기, Integer 중요도) {
-        return individualQuestionRepository.save(테스트개별질문(지원자, 내용, 순서, 면접때질문하기, 중요도));
+    public IndividualQuestion 테스트개별질문_저장하기(Applicant 지원자, String 내용, Integer 순서, boolean 면접때질문하기, Integer 중요도, Member 작성자) {
+        return individualQuestionRepository.save(테스트개별질문(지원자, 내용, 순서, 면접때질문하기, 중요도, 작성자));
     }
 
     public CommonQuestion 테스트공통질문_저장하기(Interview 면접, String 내용) {

--- a/src/test/java/com/gotcha/server/common/TestFixture.java
+++ b/src/test/java/com/gotcha/server/common/TestFixture.java
@@ -55,10 +55,11 @@ public class TestFixture {
         return new Subcollaborator(이메일, 인터뷰);
     }
 
-    public static IndividualQuestion 테스트개별질문(Applicant 지원자, String 내용, Integer 순서, boolean 면접때질문하기, Integer 중요도) {
+    public static IndividualQuestion 테스트개별질문(Applicant 지원자, String 내용, Integer 순서, boolean 면접때질문하기, Integer 중요도, Member 작성자) {
         IndividualQuestion question = IndividualQuestion.builder()
                 .applicant(지원자)
                 .content(내용)
+                .member(작성자)
                 .build();
         question.updateOrder(순서);
         question.updateImportance(중요도);

--- a/src/test/java/com/gotcha/server/common/TestTokenCreator.java
+++ b/src/test/java/com/gotcha/server/common/TestTokenCreator.java
@@ -1,0 +1,23 @@
+package com.gotcha.server.common;
+
+import static com.gotcha.server.common.TestFixture.테스트유저;
+
+import com.gotcha.server.auth.service.JwtTokenProvider;
+import com.gotcha.server.member.domain.Member;
+import com.gotcha.server.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class TestTokenCreator {
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public String create() {
+        Member member = memberRepository.save(테스트유저("토큰을 위한 테스트유저"));
+        return jwtTokenProvider.createAccessToken(member.getSocialId());
+    }
+}

--- a/src/test/java/com/gotcha/server/evaluation/service/EvaluationServiceTest.java
+++ b/src/test/java/com/gotcha/server/evaluation/service/EvaluationServiceTest.java
@@ -41,8 +41,8 @@ class EvaluationServiceTest extends IntegrationTest {
         Applicant 지원자A = environ.테스트지원자_저장하기(테스트면접, "지원자A");
         environ.테스트면접관_저장하기(지원자A, 종미);
 
-        IndividualQuestion 질문A = environ.테스트개별질문_저장하기(지원자A, "자기소개해주세요.", 1, true, 5);
-        IndividualQuestion 질문B = environ.테스트개별질문_저장하기(지원자A, "장점을소개해주세요.", 2, true, 5);
+        IndividualQuestion 질문A = environ.테스트개별질문_저장하기(지원자A, "자기소개해주세요.", 1, true, 5, 종미);
+        IndividualQuestion 질문B = environ.테스트개별질문_저장하기(지원자A, "장점을소개해주세요.", 2, true, 5, 종미);
 
         List<EvaluateRequest> 평가요청 = List.of(
                 new EvaluateRequest(질문A.getId(), 4, "좋은인상이있음"), new EvaluateRequest(질문B.getId(), 1, "낫배드"));
@@ -65,8 +65,8 @@ class EvaluationServiceTest extends IntegrationTest {
         Interviewer 종미면접관 = environ.테스트면접관_저장하기(지원자A, 종미);
         Interviewer 윤정면접관 = environ.테스트면접관_저장하기(지원자A, 윤정);
 
-        IndividualQuestion 질문A = environ.테스트개별질문_저장하기(지원자A, "자기소개해주세요.", 1, true, 5);
-        IndividualQuestion 질문B = environ.테스트개별질문_저장하기(지원자A, "장점을소개해주세요.", 2, true, 5);
+        IndividualQuestion 질문A = environ.테스트개별질문_저장하기(지원자A, "자기소개해주세요.", 1, true, 5, 종미);
+        IndividualQuestion 질문B = environ.테스트개별질문_저장하기(지원자A, "장점을소개해주세요.", 2, true, 5, 종미);
 
         environ.테스트평가_저장하기(1, "인상이좋다", 질문A, 종미);
         environ.테스트평가_저장하기(2, "굿", 질문A, 윤정);

--- a/src/test/java/com/gotcha/server/question/service/QuestionServiceIntegrationTest.java
+++ b/src/test/java/com/gotcha/server/question/service/QuestionServiceIntegrationTest.java
@@ -13,6 +13,7 @@ import com.gotcha.server.project.domain.Project;
 import com.gotcha.server.question.domain.IndividualQuestion;
 import com.gotcha.server.question.domain.QuestionPublicType;
 import com.gotcha.server.question.dto.message.QuestionUpdateMessage;
+import com.gotcha.server.question.dto.response.IndividualQuestionsResponse;
 import com.gotcha.server.question.dto.response.QuestionRankResponse;
 import com.gotcha.server.question.repository.IndividualQuestionRepository;
 import java.util.List;
@@ -33,6 +34,26 @@ public class QuestionServiceIntegrationTest extends IntegrationTest {
     @Autowired
     private IndividualQuestionRepository questionRepository;
 
+    @Test
+    @DisplayName("면접 전 질문 목록을 조회한다. 이때 작성자에 대한 정보를 포함한다.")
+    void 면접전_질문목록_조회하기() {
+        // given
+        Member 종미 = environ.테스트유저_저장하기("종미");
+        Project 테스트프로젝트 = environ.테스트프로젝트_저장하기();
+        Interview 테스트면접 = environ.테스트면접_저장하기(테스트프로젝트, "테스트면접");
+        Applicant 지원자A = environ.테스트지원자_저장하기(테스트면접, "지원자A");
+        IndividualQuestion 질문A = environ.테스트개별질문_저장하기(지원자A, "자기소개해주세요.", 1, true, 5, 종미);
+        IndividualQuestion 질문B = environ.테스트개별질문_저장하기(지원자A, "장점을소개해주세요.", 2, true, 5, 종미);
+
+        // when
+        List<IndividualQuestionsResponse> 조회결과 = questionService.listIndividualQuestions(지원자A.getId());
+
+        // then
+        assertThat(조회결과).hasSize(2)
+                .extracting(IndividualQuestionsResponse::getWriterName)
+                .contains("종미");
+    }
+
     @ParameterizedTest
     @MethodSource("수정항목_설정하기")
     @DisplayName("질문의 내용, 순서, 중요도를 하나의 메서드로 수정한다")
@@ -41,7 +62,7 @@ public class QuestionServiceIntegrationTest extends IntegrationTest {
         Project 테스트프로젝트 = environ.테스트프로젝트_저장하기();
         Interview 테스트면접 = environ.테스트면접_저장하기(테스트프로젝트, "테스트면접");
         Applicant 지원자A = environ.테스트지원자_저장하기(테스트면접, "지원자A");
-        IndividualQuestion 질문 = environ.테스트개별질문_저장하기(지원자A, "자기소개해주세요", 3, true, 3);
+        IndividualQuestion 질문 = environ.테스트개별질문_저장하기(지원자A, "자기소개해주세요", 3, true, 3, null);
 
         QuestionUpdateMessage 수정요청 = new QuestionUpdateMessage(수정내용, 수정항목);
 
@@ -71,7 +92,7 @@ public class QuestionServiceIntegrationTest extends IntegrationTest {
         Project 테스트프로젝트 = environ.테스트프로젝트_저장하기();
         Interview 테스트면접 = environ.테스트면접_저장하기(테스트프로젝트, "테스트면접");
         Applicant 지원자A = environ.테스트지원자_저장하기(테스트면접, "지원자A");
-        IndividualQuestion 질문 = environ.테스트개별질문_저장하기(지원자A, "자기소개해주세요", 3, true, 3);
+        IndividualQuestion 질문 = environ.테스트개별질문_저장하기(지원자A, "자기소개해주세요", 3, true, 3, null);
 
         environ.테스트지원자_질문공개하기(지원자A);
 
@@ -96,8 +117,8 @@ public class QuestionServiceIntegrationTest extends IntegrationTest {
         Interviewer 종미면접관 = environ.테스트면접관_저장하기(지원자A, 종미);
         Interviewer 윤정면접관 = environ.테스트면접관_저장하기(지원자A, 윤정);
 
-        IndividualQuestion 질문A = environ.테스트개별질문_저장하기(지원자A, "자기소개해주세요.", 1, true, 5);
-        IndividualQuestion 질문B = environ.테스트개별질문_저장하기(지원자A, "장점을소개해주세요.", 2, true, 5);
+        IndividualQuestion 질문A = environ.테스트개별질문_저장하기(지원자A, "자기소개해주세요.", 1, true, 5, 종미);
+        IndividualQuestion 질문B = environ.테스트개별질문_저장하기(지원자A, "장점을소개해주세요.", 2, true, 5, 종미);
 
         environ.테스트평가_저장하기(1, "인상이좋다", 질문A, 종미);
         environ.테스트평가_저장하기(2, "굿", 질문A, 윤정);

--- a/src/test/java/com/gotcha/server/question/service/QuestionServiceIntegrationTest.java
+++ b/src/test/java/com/gotcha/server/question/service/QuestionServiceIntegrationTest.java
@@ -96,8 +96,8 @@ public class QuestionServiceIntegrationTest extends IntegrationTest {
         Interviewer 종미면접관 = environ.테스트면접관_저장하기(지원자A, 종미);
         Interviewer 윤정면접관 = environ.테스트면접관_저장하기(지원자A, 윤정);
 
-        IndividualQuestion 질문A = environ.테스트개별질문_저장하기(지원자A, "자기소개해주세요.", 1, true, 1);
-        IndividualQuestion 질문B = environ.테스트개별질문_저장하기(지원자A, "장점을소개해주세요.", 2, true, 1);
+        IndividualQuestion 질문A = environ.테스트개별질문_저장하기(지원자A, "자기소개해주세요.", 1, true, 5);
+        IndividualQuestion 질문B = environ.테스트개별질문_저장하기(지원자A, "장점을소개해주세요.", 2, true, 5);
 
         environ.테스트평가_저장하기(1, "인상이좋다", 질문A, 종미);
         environ.테스트평가_저장하기(2, "굿", 질문A, 윤정);
@@ -110,6 +110,6 @@ public class QuestionServiceIntegrationTest extends IntegrationTest {
         // then
         assertThat(조회결과).hasSize(2)
                 .extracting(QuestionRankResponse::totalScore)
-                .containsExactlyElementsOf(List.of(3.5, 1.5));
+                .containsExactlyElementsOf(List.of(17.5, 7.5));
     }
 }

--- a/src/test/java/com/gotcha/server/stomp/StompIntegrationTest.java
+++ b/src/test/java/com/gotcha/server/stomp/StompIntegrationTest.java
@@ -96,7 +96,7 @@ public class StompIntegrationTest {
     void 질문_수정하기() throws Exception {
         // given
         given(individualQuestionRepository.findById(1L)).willReturn(
-                Optional.of(테스트개별질문(null, "자기소개해주세요.", 0, true, 5)));
+                Optional.of(테스트개별질문(null, "자기소개해주세요.", 0, true, 5, null)));
 
         String URL = String.format("ws://localhost:%d/ws", port);
         String jwtToken = testTokenCreator.create();

--- a/src/test/java/com/gotcha/server/stomp/StompIntegrationTest.java
+++ b/src/test/java/com/gotcha/server/stomp/StompIntegrationTest.java
@@ -5,7 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.BDDMockito.given;
 
+import com.gotcha.server.common.DatabaseCleaner;
 import com.gotcha.server.common.TestRepository;
+import com.gotcha.server.common.TestTokenCreator;
 import com.gotcha.server.question.dto.message.QuestionUpdateMessage;
 import com.gotcha.server.question.repository.IndividualQuestionRepository;
 import com.gotcha.server.question.service.QuestionUpdateType;
@@ -15,19 +17,25 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.simp.stomp.StompHeaders;
 import org.springframework.messaging.simp.stomp.StompSession;
 import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.socket.WebSocketHttpHeaders;
 import org.springframework.web.socket.client.standard.StandardWebSocketClient;
 import org.springframework.web.socket.messaging.WebSocketStompClient;
 import org.springframework.web.socket.sockjs.client.SockJsClient;
 import org.springframework.web.socket.sockjs.client.WebSocketTransport;
 
 @Slf4j
+@ActiveProfiles(profiles = "dev")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class StompIntegrationTest {
     @LocalServerPort
@@ -39,10 +47,21 @@ public class StompIntegrationTest {
     @MockBean
     private IndividualQuestionRepository individualQuestionRepository;
 
+    @Autowired
+    private TestTokenCreator testTokenCreator;
+
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
     private final WebSocketStompClient stompClient;
 
     public StompIntegrationTest() {
         this.stompClient = getStompClient();
+    }
+
+    @BeforeEach
+    void setUp() {
+        databaseCleaner.clear();
     }
 
     private WebSocketStompClient getStompClient() {
@@ -57,26 +76,46 @@ public class StompIntegrationTest {
     @Test
     void 웹소켓_연결하기() {
         // given
-        String url = String.format("ws://localhost:%d/ws", port);
+        String URL = String.format("ws://localhost:%d/ws", port);
+        String jwtToken = testTokenCreator.create();
+
+        StompHeaders stompHeaders = new StompHeaders();
+        stompHeaders.setLogin("Bearer " + jwtToken);
 
         // when & then
         assertDoesNotThrow(() -> {
-            stompClient.connectAsync(url,new StompSessionHandlerAdapter(){}).get(2, TimeUnit.SECONDS);
+            stompClient.connectAsync(
+                    URL,
+                    new WebSocketHttpHeaders(),
+                    stompHeaders,
+                    new StompSessionHandlerAdapter(){}).get(2, TimeUnit.SECONDS);
         });
     }
 
     @Test
     void 질문_수정하기() throws Exception {
         // given
-        String URL = String.format("ws://localhost:%d/ws", port);
         given(individualQuestionRepository.findById(1L)).willReturn(
                 Optional.of(테스트개별질문(null, "자기소개해주세요.", 0, true, 5)));
 
+        String URL = String.format("ws://localhost:%d/ws", port);
+        String jwtToken = testTokenCreator.create();
+
+        StompHeaders connectionHeaders = new StompHeaders();
+        connectionHeaders.setLogin("Bearer " + jwtToken);
         BlockingQueue<QuestionUpdateMessage> blockingQueue = new LinkedBlockingQueue<>();
-        StompSession session = getStompClient().connectAsync(URL, new TestSessionHandler(blockingQueue)).get(2, TimeUnit.SECONDS);
+        StompSession session = getStompClient().connectAsync(
+                URL,
+                new WebSocketHttpHeaders(),
+                connectionHeaders,
+                new TestSessionHandler(blockingQueue, jwtToken)).get(2, TimeUnit.SECONDS);
+
+        StompHeaders pubHeaders = new StompHeaders();
+        pubHeaders.setLogin("Bearer " + jwtToken);
+        pubHeaders.setDestination("/pub/question/1");
 
         // when
-        session.send("/pub/question/1", new QuestionUpdateMessage("바뀐내용", QuestionUpdateType.CONTENT));
+        session.send(pubHeaders, new QuestionUpdateMessage("바뀐내용", QuestionUpdateType.CONTENT));
         QuestionUpdateMessage 발행된_메세지 = blockingQueue.poll(2, TimeUnit.SECONDS);
 
         // then

--- a/src/test/java/com/gotcha/server/stomp/TestSessionHandler.java
+++ b/src/test/java/com/gotcha/server/stomp/TestSessionHandler.java
@@ -13,14 +13,19 @@ import org.springframework.messaging.simp.stomp.StompSessionHandler;
 @Slf4j
 public class TestSessionHandler implements StompSessionHandler {
     private final BlockingQueue<QuestionUpdateMessage> blockingQueue;
+    private final String jwtToken;
 
-    public TestSessionHandler(BlockingQueue<QuestionUpdateMessage> blockingQueue) {
+    public TestSessionHandler(BlockingQueue<QuestionUpdateMessage> blockingQueue, String jwtToken) {
         this.blockingQueue = blockingQueue;
+        this.jwtToken = jwtToken;
     }
 
     @Override
     public void afterConnected(StompSession session, StompHeaders connectedHeaders) {
-        session.subscribe("/sub/question/1", this);
+        StompHeaders subHeaders = new StompHeaders();
+        subHeaders.setLogin("Bearer " + jwtToken);
+        subHeaders.setDestination("/sub/question/1");
+        session.subscribe(subHeaders, this);
     }
 
     @Override


### PR DESCRIPTION
## Check 🌈

- [x] 배포 브랜치에 바로 merge합니다
- [x] merge는 PR 작성자가 합니다

## Description 📒

>기능 추가/수정 사항
>1. 웹소켓 통신 시 인증 과정 추가
>2. 면접 전 개별 질문 목록 조회 기능
>3. 🚨 개별 면접 질문 생성 기능 Fix (제가 구현했던 게 아니라서 꼭 확인해주세요!)

## To Reviewer 💬

`3. 🚨 개별 면접 질문 생성 기능`의 경우, DTO 메서드에서 레포지토리를 인자로 받는 것에 오류가 있어 수정했는데, 배포가 급해서 일단 제가 수정했읍니다.. 리팩토링 하시면 좋을 것 같아용
1. DTO에서는 영속성 컨텍스트 적용 안될 수 있음
2. DTO에는 서비스 로직이 존재하면 안됨 (DTO 쓰는 의미가 없음)