### PR TITLE
유저의 email 수정과 지원자 즐겨찾기 기능 구현, 쿼리 오류 수정

### DIFF
--- a/src/main/java/com/gotcha/server/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/gotcha/server/applicant/controller/ApplicantController.java
@@ -29,19 +29,22 @@ public class ApplicantController {
     @PostMapping("/interview-ready")
     @Operation(description = "로그인 유저(면접관)가 면접 준비 완료를 요청한다. 모든 면접관이 준비 완료되었다면 지원자의 면접 단계가 바뀐다.")
     public ResponseEntity<InterviewProceedResponse> proceedToInterview(
-            @RequestBody final InterviewProceedRequest request, @AuthenticationPrincipal final MemberDetails details) {
+            @RequestBody final InterviewProceedRequest request,
+            @AuthenticationPrincipal final MemberDetails details) {
         return ResponseEntity.ok(applicantService.proceedToInterview(request, details));
     }
 
     @GetMapping
     @Operation(description = "세부 면접의 모든 지원자를 면접일 순으로 조회한다. 발표 완료된(ANNOUNCED) 지원자는 조회하지 않는다.")
-    public ResponseEntity<List<ApplicantsResponse>> findAllApplicantByInterview(@RequestParam(name = "interview-id") final Long interviewId) {
+    public ResponseEntity<List<ApplicantsResponse>> findAllApplicantByInterview(
+            @RequestParam(name = "interview-id") final Long interviewId) {
         return ResponseEntity.ok(applicantService.listApplicantsByInterview(interviewId));
     }
 
     @GetMapping("/{applicant-id}")
     @Operation(description = "지원자의 상세 정보를 조회한다.")
-    public ResponseEntity<ApplicantResponse> findApplicantDetailsById(@PathVariable(name = "applicant-id") final Long applicantId) {
+    public ResponseEntity<ApplicantResponse> findApplicantDetailsById(
+            @PathVariable(name = "applicant-id") final Long applicantId) {
         return ResponseEntity.ok(applicantService.findApplicantDetailsById(applicantId));
     }
 
@@ -56,7 +59,8 @@ public class ApplicantController {
 
     @GetMapping("/pass")
     @Operation(description = "면접 진행 완료(COMPLETION) 지원자 중 합격한 지원자 목록을 조회한다.")
-    public ResponseEntity<List<PassedApplicantsResponse>> findAllPassedApplicantsByInterview(@RequestParam(name = "interview-id") final Long interviewId) {
+    public ResponseEntity<List<PassedApplicantsResponse>> findAllPassedApplicantsByInterview(
+            @RequestParam(name = "interview-id") final Long interviewId) {
         return ResponseEntity.ok(applicantService.listPassedApplicantsByInterview(interviewId));
     }
 
@@ -69,16 +73,16 @@ public class ApplicantController {
 
     @PostMapping
     public ResponseEntity<String> createApplicant(
-            @RequestBody @Valid ApplicantRequest request,
-            @AuthenticationPrincipal MemberDetails details) {
+            @RequestBody final ApplicantRequest request,
+            @AuthenticationPrincipal final MemberDetails details) {
         applicantService.createApplicant(request, details.member());
         return ResponseEntity.status(HttpStatus.CREATED).body("면접 지원자 정보가 입력되었습니다.");
     }
 
     @PostMapping("/files")
     public ResponseEntity<String> addApplicantFiles(
-            @RequestParam(required = false) MultipartFile resume,
-            @RequestParam(required = false) MultipartFile portfolio,
+            @RequestParam(required = false) final MultipartFile resume,
+            @RequestParam(required = false) final MultipartFile portfolio,
             @RequestParam(name = "applicant-id") final Long applicantId
     ) throws IOException {
         applicantService.addApplicantFiles(resume, portfolio, applicantId);
@@ -86,12 +90,14 @@ public class ApplicantController {
     }
 
     @GetMapping("/interview-completed")
-    public ResponseEntity<List<CompletedApplicantsResponse>> getCompletedApplicants(@RequestParam(value = "interview-id") Long interviewId) {
+    public ResponseEntity<List<CompletedApplicantsResponse>> getCompletedApplicants(
+            @RequestParam(value = "interview-id") final Long interviewId) {
         return ResponseEntity.status(HttpStatus.OK).body(applicantService.getCompletedApplicants(interviewId));
     }
 
     @GetMapping("/interview-completed/details")
-    public ResponseEntity<CompletedApplicantDetailsResponse> getCompletedApplicantDetails(@RequestParam(value = "applicant-id") Long applicantId) {
+    public ResponseEntity<CompletedApplicantDetailsResponse> getCompletedApplicantDetails(
+            @RequestParam(value = "applicant-id") final Long applicantId) {
         return ResponseEntity.status(HttpStatus.OK).body(applicantService.getCompletedApplicantDetails(applicantId));
     }
 }

--- a/src/main/java/com/gotcha/server/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/gotcha/server/applicant/controller/ApplicantController.java
@@ -37,8 +37,9 @@ public class ApplicantController {
     @GetMapping
     @Operation(description = "세부 면접의 모든 지원자를 면접일 순으로 조회한다. 발표 완료된(ANNOUNCED) 지원자는 조회하지 않는다.")
     public ResponseEntity<List<ApplicantsResponse>> findAllApplicantByInterview(
-            @RequestParam(name = "interview-id") final Long interviewId) {
-        return ResponseEntity.ok(applicantService.listApplicantsByInterview(interviewId));
+            @RequestParam(name = "interview-id") final Long interviewId,
+            @AuthenticationPrincipal final MemberDetails details) {
+        return ResponseEntity.ok(applicantService.listApplicantsByInterview(interviewId, details));
     }
 
     @GetMapping("/{applicant-id}")

--- a/src/main/java/com/gotcha/server/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/gotcha/server/applicant/controller/ApplicantController.java
@@ -48,6 +48,15 @@ public class ApplicantController {
         return ResponseEntity.ok(applicantService.findApplicantDetailsById(applicantId));
     }
 
+    @PostMapping("/{applicant-id}/favorite")
+    @Operation(description = "지원자를 즐겨찾기 하거나 취소한다.")
+    public ResponseEntity<Void> updateFavorite(
+            @PathVariable(name = "applicant-id") final Long applicantId,
+            @AuthenticationPrincipal final MemberDetails details) {
+        applicantService.updateFavorite(applicantId, details);
+        return ResponseEntity.ok().build();
+    }
+
     @PostMapping("/{applicant-id}/public")
     @Operation(description = "지원자의 면접 질문 공개를 동의 혹은 비동의한다.")
     public ResponseEntity<Void> makeQuestionsPublic(

--- a/src/main/java/com/gotcha/server/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/gotcha/server/applicant/controller/ApplicantController.java
@@ -70,8 +70,9 @@ public class ApplicantController {
     @GetMapping("/pass")
     @Operation(description = "면접 진행 완료(COMPLETION) 지원자 중 합격한 지원자 목록을 조회한다.")
     public ResponseEntity<List<PassedApplicantsResponse>> findAllPassedApplicantsByInterview(
-            @RequestParam(name = "interview-id") final Long interviewId) {
-        return ResponseEntity.ok(applicantService.listPassedApplicantsByInterview(interviewId));
+            @RequestParam(name = "interview-id") final Long interviewId,
+            @AuthenticationPrincipal final MemberDetails details) {
+        return ResponseEntity.ok(applicantService.listPassedApplicantsByInterview(interviewId, details));
     }
 
     @PostMapping("/send-email")

--- a/src/main/java/com/gotcha/server/applicant/domain/Favorite.java
+++ b/src/main/java/com/gotcha/server/applicant/domain/Favorite.java
@@ -1,0 +1,35 @@
+package com.gotcha.server.applicant.domain;
+
+import com.gotcha.server.member.domain.Member;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Favorite {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false, name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false, name = "applicant_id")
+    private Applicant applicant;
+
+    public Favorite(final Member member, final Applicant applicant) {
+        this.member = member;
+        this.applicant = applicant;
+    }
+}

--- a/src/main/java/com/gotcha/server/applicant/dto/request/ApplicantRequest.java
+++ b/src/main/java/com/gotcha/server/applicant/dto/request/ApplicantRequest.java
@@ -1,10 +1,7 @@
 package com.gotcha.server.applicant.dto.request;
 
 import com.gotcha.server.applicant.domain.*;
-import com.gotcha.server.global.exception.AppException;
-import com.gotcha.server.global.exception.ErrorCode;
 import com.gotcha.server.project.domain.Interview;
-import com.gotcha.server.project.repository.InterviewRepository;
 import com.gotcha.server.question.dto.request.IndividualQuestionRequest;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/gotcha/server/applicant/dto/response/ApplicantsResponse.java
+++ b/src/main/java/com/gotcha/server/applicant/dto/response/ApplicantsResponse.java
@@ -35,7 +35,12 @@ public class ApplicantsResponse {
     @Schema(description = "키워드 목록 (타입별하나씩)")
     private List<KeywordResponse> keywords;
 
-    public static List<ApplicantsResponse> generateList(final Map<Applicant, List<KeywordResponse>> applicantsWithKeywords) {
+    @Schema(description = "즐겨찾기")
+    private Boolean favorite;
+
+    public static List<ApplicantsResponse> generateList(
+            final Map<Applicant, List<KeywordResponse>> applicantsWithKeywords,
+            final Map<Applicant, Boolean> favoritesCheck) {
         return applicantsWithKeywords.keySet().stream()
                         .map(applicant -> ApplicantsResponse.builder()
                                 .id(applicant.getId())
@@ -47,6 +52,7 @@ public class ApplicantsResponse {
                                         .toList())
                                 .questionCount(applicant.getQuestions().size())
                                 .keywords(applicantsWithKeywords.get(applicant))
+                                .favorite(favoritesCheck.get(applicant))
                                 .build())
                                 .toList();
     }

--- a/src/main/java/com/gotcha/server/applicant/dto/response/PassedApplicantsResponse.java
+++ b/src/main/java/com/gotcha/server/applicant/dto/response/PassedApplicantsResponse.java
@@ -18,8 +18,11 @@ public class PassedApplicantsResponse {
     private Integer score;
     private Integer rank;
     private List<String> keywords;
+    private Boolean favorite;
 
-    public static List<PassedApplicantsResponse> generateList(final Map<Applicant, List<KeywordResponse>> applicantsWithKeywords) {
+    public static List<PassedApplicantsResponse> generateList(
+            final Map<Applicant, List<KeywordResponse>> applicantsWithKeywords,
+            final Map<Applicant, Boolean> favoritesCheck) {
         return applicantsWithKeywords.keySet().stream()
                 .map(applicant -> PassedApplicantsResponse.builder()
                         .id(applicant.getId())
@@ -27,6 +30,7 @@ public class PassedApplicantsResponse {
                         .score(applicant.getTotalScore())
                         .rank(applicant.getRanking())
                         .keywords(applicantsWithKeywords.get(applicant).stream().map(KeywordResponse::name).toList())
+                        .favorite(favoritesCheck.get(applicant))
                         .build())
                 .toList();
     }

--- a/src/main/java/com/gotcha/server/applicant/repository/ApplicantDslRepositoryImpl.java
+++ b/src/main/java/com/gotcha/server/applicant/repository/ApplicantDslRepositoryImpl.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Repository;
 public class ApplicantDslRepositoryImpl implements ApplicantDslRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
+    // Todo: one to may fetch join은 한 번만 되므로 IndividualQuestion에 대한 쿼리 한번 더 나감
     @Override
     public List<Applicant> findAllByInterviewWithInterviewer(final Interview interview) {
         QApplicant qApplicant = QApplicant.applicant;

--- a/src/main/java/com/gotcha/server/applicant/repository/ApplicantDslRepositoryImpl.java
+++ b/src/main/java/com/gotcha/server/applicant/repository/ApplicantDslRepositoryImpl.java
@@ -28,9 +28,9 @@ public class ApplicantDslRepositoryImpl implements ApplicantDslRepository {
         return jpaQueryFactory
                 .select(qApplicant)
                 .from(qApplicant)
-                .innerJoin(qApplicant.interviewers, qInterviewer)
+                .leftJoin(qApplicant.interviewers, qInterviewer)
                 .fetchJoin()
-                .innerJoin(qInterviewer.member, qMember)
+                .leftJoin(qInterviewer.member, qMember)
                 .fetchJoin()
                 .leftJoin(qApplicant.questions, qQuestion)
                 .where(qApplicant.interview.eq(interview), qApplicant.interviewStatus.ne(InterviewStatus.ANNOUNCED))

--- a/src/main/java/com/gotcha/server/applicant/repository/FavoriteRepository.java
+++ b/src/main/java/com/gotcha/server/applicant/repository/FavoriteRepository.java
@@ -3,9 +3,11 @@ package com.gotcha.server.applicant.repository;
 import com.gotcha.server.applicant.domain.Applicant;
 import com.gotcha.server.applicant.domain.Favorite;
 import com.gotcha.server.member.domain.Member;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
     Optional<Favorite> findByApplicantAndMember(Applicant applicant, Member member);
+    List<Favorite> findAllByMemberAndApplicantIn(Member member, List<Applicant> applicants);
 }

--- a/src/main/java/com/gotcha/server/applicant/repository/FavoriteRepository.java
+++ b/src/main/java/com/gotcha/server/applicant/repository/FavoriteRepository.java
@@ -1,0 +1,11 @@
+package com.gotcha.server.applicant.repository;
+
+import com.gotcha.server.applicant.domain.Applicant;
+import com.gotcha.server.applicant.domain.Favorite;
+import com.gotcha.server.member.domain.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+    Optional<Favorite> findByApplicantAndMember(Applicant applicant, Member member);
+}

--- a/src/main/java/com/gotcha/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/gotcha/server/applicant/service/ApplicantService.java
@@ -124,12 +124,15 @@ public class ApplicantService {
                 () -> favoriteRepository.save(new Favorite(member, applicant)));
     }
 
-    public List<PassedApplicantsResponse> listPassedApplicantsByInterview(final Long interviewId) {
+    public List<PassedApplicantsResponse> listPassedApplicantsByInterview(final Long interviewId,  final MemberDetails details) {
         Interview interview = interviewRepository.findById(interviewId)
                 .orElseThrow(() -> new AppException(ErrorCode.INTERVIEW_NOT_FOUNT));
         List<Applicant> applicants = applicantRepository.findAllPassedApplicants(interview);
+
         Map<Applicant, List<KeywordResponse>> applicantsWithKeywords = keywordRepository.findAllByApplicants(applicants);
-        return PassedApplicantsResponse.generateList(applicantsWithKeywords);
+        Map<Applicant, Boolean> favoritesCheck = checkFavorites(applicants, details.member());
+
+        return PassedApplicantsResponse.generateList(applicantsWithKeywords, favoritesCheck);
     }
 
     @Transactional

--- a/src/main/java/com/gotcha/server/evaluation/controller/EvaluationController.java
+++ b/src/main/java/com/gotcha/server/evaluation/controller/EvaluationController.java
@@ -21,21 +21,26 @@ public class EvaluationController {
 
     @PostMapping
     @Operation(description = "면접 중, 사전 작성된 질문들에 코멘트와 점수(0~5점)를 기록한다.")
-    public ResponseEntity<Void> evaluate(@AuthenticationPrincipal final MemberDetails details, @RequestBody final List<EvaluateRequest> requests) {
+    public ResponseEntity<Void> evaluate(
+            @AuthenticationPrincipal final MemberDetails details,
+            @RequestBody final List<EvaluateRequest> requests) {
         evaluationService.evaluate(details, requests);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @PostMapping("/one-liner")
     @Operation(description = "로그인 유저(면접관)가 지원자에게 한줄평을 작성한다.")
-    public ResponseEntity<Void> createOneLiner(@AuthenticationPrincipal final MemberDetails details, @RequestBody final OneLinerRequest request) {
+    public ResponseEntity<Void> createOneLiner(
+            @AuthenticationPrincipal final MemberDetails details,
+            @RequestBody final OneLinerRequest request) {
         evaluationService.createOneLiner(details, request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @GetMapping("/questions")
     @Operation(description = "질문에 대해 모든 면접관의 평가를 조회한다.")
-    public ResponseEntity<QuestionEvaluationResponse> findEvaluationsByQuestion(@RequestParam(value = "question-id") Long questionId) {
+    public ResponseEntity<QuestionEvaluationResponse> findEvaluationsByQuestion(
+            @RequestParam(value = "question-id") final Long questionId) {
         return ResponseEntity.ok(evaluationService.findQuestionEvaluations(questionId));
     }
 }

--- a/src/main/java/com/gotcha/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/gotcha/server/global/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     NO_PARAMETER(HttpStatus.BAD_REQUEST, " 파라미터가 없습니다."),
     NAME_IS_EMPTY(HttpStatus.BAD_REQUEST, "면접 이름을 입력해주세요."),
     INVALID_EMAIL(HttpStatus.BAD_REQUEST, "유효하지 않은 이메일 주소입니다."),
+    INVALID_GOOGLE_EMAIL(HttpStatus.BAD_REQUEST, "구글 이메일 주소가 아닙니다."),
     INVALID_IMPORTANCE(HttpStatus.BAD_REQUEST, "중요도의 범위는 3~5입니다."),
     CONTENT_IS_EMPTY(HttpStatus.BAD_REQUEST, "내용을 입력해주세요."),
     MULTIPLE_APPLICANT_EVALUATION(HttpStatus.BAD_REQUEST, "동일하지 않은 지원자에 대한 평가 요청입니다.."),

--- a/src/main/java/com/gotcha/server/member/controller/MemberController.java
+++ b/src/main/java/com/gotcha/server/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.gotcha.server.member.controller;
 
+import com.gotcha.server.member.dto.request.EmailModifyRequest;
 import com.gotcha.server.member.dto.response.TodayInterviewResponse;
 import com.gotcha.server.auth.dto.response.RefreshTokenResponse;
 import com.gotcha.server.auth.dto.request.MemberDetails;
@@ -11,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -43,6 +45,14 @@ public class MemberController {
     @Operation(description = "로그아웃한다.")
     public ResponseEntity<Void> logout(@AuthenticationPrincipal final MemberDetails details) {
         memberService.logout(details);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/api/user/email")
+    @Operation(description = "유저의 이메일을 수정한다.")
+    public ResponseEntity<Void> modifyEmail(
+            @AuthenticationPrincipal final MemberDetails details, @RequestBody final EmailModifyRequest request) {
+        memberService.modifyEmail(details, request);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/gotcha/server/member/controller/MemberController.java
+++ b/src/main/java/com/gotcha/server/member/controller/MemberController.java
@@ -25,19 +25,23 @@ public class MemberController {
 
     @GetMapping("/api/login/google")
     @Operation(description = "access token과 refresh token을 발급 받는다. 회원가입 되지 않은 유저라면 가입한다.")
-    public ResponseEntity<LoginResponse> getGoogleToken(@RequestParam String code, @RequestParam(value = "redirect-uri") String redirectUri) {
+    public ResponseEntity<LoginResponse> getGoogleToken(
+            @RequestParam final String code,
+            @RequestParam(value = "redirect-uri") final String redirectUri) {
         return ResponseEntity.ok(memberService.login(code, redirectUri));
     }
 
     @PostMapping("/api/refresh")
     @Operation(description = "access token을 재발급 받는다.")
-    public ResponseEntity<RefreshTokenResponse> refreshToken(@RequestBody RefreshTokenRequest request) {
+    public ResponseEntity<RefreshTokenResponse> refreshToken(
+            @RequestBody final RefreshTokenRequest request) {
         return ResponseEntity.ok(memberService.refresh(request));
     }
 
     @GetMapping("/api/todays-interview")
     @Operation(description = "로그인한 유저의 오늘 예정된 면접 수를 조회한다.")
-    public ResponseEntity<TodayInterviewResponse> countInterview(@AuthenticationPrincipal final MemberDetails details) {
+    public ResponseEntity<TodayInterviewResponse> countInterview(
+            @AuthenticationPrincipal final MemberDetails details) {
         return ResponseEntity.ok(memberService.countTodayInterview(details));
     }
 
@@ -51,7 +55,8 @@ public class MemberController {
     @PatchMapping("/api/user/email")
     @Operation(description = "유저의 이메일을 수정한다.")
     public ResponseEntity<Void> modifyEmail(
-            @AuthenticationPrincipal final MemberDetails details, @RequestBody final EmailModifyRequest request) {
+            @AuthenticationPrincipal final MemberDetails details,
+            @RequestBody final EmailModifyRequest request) {
         memberService.modifyEmail(details, request);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/gotcha/server/member/domain/Member.java
+++ b/src/main/java/com/gotcha/server/member/domain/Member.java
@@ -1,6 +1,8 @@
 package com.gotcha.server.member.domain;
 
 import com.gotcha.server.global.domain.BaseTimeEntity;
+import com.gotcha.server.global.exception.AppException;
+import com.gotcha.server.global.exception.ErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -54,5 +56,16 @@ public class Member extends BaseTimeEntity {
 
     public void updateRefreshToken(final String refreshToken) {
         this.refreshToken = refreshToken;
+    }
+
+    public void updateEmail(final String email) {
+        validateEmail(email);
+        this.email = email;
+    }
+
+    private void validateEmail(final String email) {
+        if(!email.endsWith("@gmail.com")) {
+            throw new AppException(ErrorCode.INVALID_GOOGLE_EMAIL);
+        }
     }
 }

--- a/src/main/java/com/gotcha/server/member/dto/request/EmailModifyRequest.java
+++ b/src/main/java/com/gotcha/server/member/dto/request/EmailModifyRequest.java
@@ -1,0 +1,5 @@
+package com.gotcha.server.member.dto.request;
+
+public record EmailModifyRequest(String email) {
+
+}

--- a/src/main/java/com/gotcha/server/member/service/MemberService.java
+++ b/src/main/java/com/gotcha/server/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.gotcha.server.member.service;
 
 import com.gotcha.server.auth.service.JwtTokenProvider;
+import com.gotcha.server.member.dto.request.EmailModifyRequest;
 import com.gotcha.server.member.dto.response.TodayInterviewResponse;
 import com.gotcha.server.applicant.repository.InterviewerRepository;
 import com.gotcha.server.auth.dto.response.RefreshTokenResponse;
@@ -65,5 +66,12 @@ public class MemberService {
     public TodayInterviewResponse countTodayInterview(final MemberDetails details) {
         long count = interviewerRepository.countTodayInterview(details.member());
         return new TodayInterviewResponse(count);
+    }
+
+    @Transactional
+    public void modifyEmail(final MemberDetails details, final EmailModifyRequest request) {
+        Member member = details.member();
+        member.updateEmail(request.email());
+        memberRepository.save(member);
     }
 }

--- a/src/main/java/com/gotcha/server/project/controller/InterviewController.java
+++ b/src/main/java/com/gotcha/server/project/controller/InterviewController.java
@@ -21,14 +21,13 @@ public class InterviewController {
     private final InterviewService interviewService;
 
     @PostMapping
-    public ResponseEntity<String> createInterview(
-            @RequestBody @Valid InterviewRequest request) {
+    public ResponseEntity<String> createInterview(@RequestBody final InterviewRequest request) {
         interviewService.createInterview(request);
         return ResponseEntity.status(HttpStatus.CREATED).body("세부 면접 생성 및 초대 이메일 발송이 완료되었습니다.");
     }
 
     @GetMapping("/{interviewId}/names")
-    public ResponseEntity<List<InterviewerNamesResponse>> getNames(@PathVariable Long interviewId){
+    public ResponseEntity<List<InterviewerNamesResponse>> getNames(@PathVariable final Long interviewId){
         return ResponseEntity.status(HttpStatus.OK).body(interviewService.getInterviewerNames(interviewId));
     }
 

--- a/src/main/java/com/gotcha/server/project/controller/ProjectController.java
+++ b/src/main/java/com/gotcha/server/project/controller/ProjectController.java
@@ -5,7 +5,6 @@ import com.gotcha.server.project.dto.request.ProjectRequest;
 import com.gotcha.server.project.dto.response.ProjectResponse;
 import com.gotcha.server.project.dto.response.SidebarResponse;
 import com.gotcha.server.project.service.ProjectService;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,19 +20,18 @@ public class ProjectController {
     private final ProjectService projectService;
 
     @PostMapping
-    public ResponseEntity<String> createProject(
-            @RequestBody @Valid ProjectRequest request) {
+    public ResponseEntity<String> createProject(@RequestBody final ProjectRequest request) {
         projectService.createProject(request);
         return ResponseEntity.status(HttpStatus.CREATED).body("프로젝트 생성 및 초대 이메일 발송이 완료되었습니다.");
     }
 
     @GetMapping("/{projectId}/emails")
-    public ResponseEntity<ProjectResponse> getEmails(@PathVariable Long projectId){
+    public ResponseEntity<ProjectResponse> getEmails(@PathVariable final Long projectId){
         return ResponseEntity.status(HttpStatus.OK).body(projectService.getEmails(projectId));
     }
 
     @GetMapping
-    public ResponseEntity<SidebarResponse> getSidebar(@AuthenticationPrincipal MemberDetails details){
+    public ResponseEntity<SidebarResponse> getSidebar(@AuthenticationPrincipal final MemberDetails details){
 //        //테스트용 유저 생성
 //        Member member = Member.builder()
 //                .email("a@gmail.co")

--- a/src/main/java/com/gotcha/server/project/dto/request/InterviewRequest.java
+++ b/src/main/java/com/gotcha/server/project/dto/request/InterviewRequest.java
@@ -8,7 +8,6 @@ import com.gotcha.server.project.domain.PositionType;
 import com.gotcha.server.project.domain.Project;
 import com.gotcha.server.project.repository.ProjectRepository;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/gotcha/server/question/controller/QuestionController.java
+++ b/src/main/java/com/gotcha/server/question/controller/QuestionController.java
@@ -11,7 +11,6 @@ import com.gotcha.server.question.service.QuestionService;
 import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,40 +25,45 @@ public class QuestionController {
 
     @PostMapping("/common")
     @Operation(description = "공통 질문을 생성한다.")
-    public ResponseEntity<Void> createCommonQuestions(@RequestBody final CommonQuestionsRequest request) {
+    public ResponseEntity<Void> createCommonQuestions(
+            @RequestBody final CommonQuestionsRequest request) {
         questionService.createCommonQuestions(request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @GetMapping
     @Operation(description = "면접 전 지원자의 개별 질문 목록을 조회한다.")
-    public ResponseEntity<List<IndividualQuestionsResponse>> findAllIndividualQuestions(@RequestParam(name = "applicant-id") Long applicantId) {
+    public ResponseEntity<List<IndividualQuestionsResponse>> findAllIndividualQuestions(
+            @RequestParam(name = "applicant-id") final Long applicantId) {
         return ResponseEntity.ok(questionService.listIndividualQuestions(applicantId));
     }
 
     @GetMapping("/in-progress")
     @Operation(description = "지원자의 면접 중 질문 목록을 순서대로 조회한다.")
-    public ResponseEntity<List<InterviewQuestionResponse>> findAllInterviewQuestions(@RequestParam(name = "applicant-id") Long applicantId) {
+    public ResponseEntity<List<InterviewQuestionResponse>> findAllInterviewQuestions(
+            @RequestParam(name = "applicant-id") final Long applicantId) {
         return ResponseEntity.ok(questionService.listInterviewQuestions(applicantId));
     }
 
     @PostMapping("/individual")
     public ResponseEntity<String> createIndividualQuestion(
-            @RequestBody @Valid IndividualQuestionRequest request,
-            @AuthenticationPrincipal MemberDetails details) {
+            @RequestBody final IndividualQuestionRequest request,
+            @AuthenticationPrincipal final MemberDetails details) {
         questionService.createIndividualQuestion(request, details.member());
         return ResponseEntity.status(HttpStatus.CREATED).body("개별 질문이 입력되었습니다.");
     }
 
     @GetMapping("/preparatory")
     @Operation(description = "면접 전 질문 확인 창에서 질문 목록을 조회한다.")
-    public ResponseEntity<List<PreparatoryQuestionResponse>> findAllPreparatoryQuestions(@RequestParam(value = "applicant-id") Long applicantId) {
+    public ResponseEntity<List<PreparatoryQuestionResponse>> findAllPreparatoryQuestions(
+            @RequestParam(value = "applicant-id") final Long applicantId) {
         return ResponseEntity.ok(questionService.listPreparatoryQuestions(applicantId));
     }
 
     @GetMapping("/rank")
     @Operation(description = "면접 후, 지원자의 모든 면접 질문 id를 총점 순으로 조회한다.")
-    public ResponseEntity<List<QuestionRankResponse>> findQuestionRanksByApplicant(@RequestParam(value = "applicant-id") Long applicantId) {
+    public ResponseEntity<List<QuestionRankResponse>> findQuestionRanksByApplicant(
+            @RequestParam(value = "applicant-id") final Long applicantId) {
         return ResponseEntity.ok(questionService.findQuestionRanks(applicantId));
     }
 }

--- a/src/test/java/com/gotcha/server/applicant/repository/FavoriteRepositoryTest.java
+++ b/src/test/java/com/gotcha/server/applicant/repository/FavoriteRepositoryTest.java
@@ -1,0 +1,45 @@
+package com.gotcha.server.applicant.repository;
+
+import static com.gotcha.server.common.TestFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gotcha.server.applicant.domain.Applicant;
+import com.gotcha.server.applicant.domain.Favorite;
+import com.gotcha.server.common.RepositoryTest;
+import com.gotcha.server.member.domain.Member;
+import com.gotcha.server.project.domain.Interview;
+import com.gotcha.server.project.domain.Project;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class FavoriteRepositoryTest extends RepositoryTest {
+    @Autowired
+    private FavoriteRepository favoriteRepository;
+
+    @Test
+    @DisplayName("지원자 목록에 대해서 유저가 즐겨찾기한 여부를 조회한다.")
+    void 지원자목록에서_즐겨찾기여부_조회하기() {
+        // given
+        Member 종미 = 테스트유저("종미");
+        Project 프로젝트 = 테스트프로젝트();
+        Interview 면접 = 테스트면접(프로젝트, "테스트면접");
+        Applicant 지원자A = 테스트지원자(면접, "지원자A");
+        Applicant 지원자B = 테스트지원자(면접, "지원자B");
+        Applicant 지원자C = 테스트지원자(면접, "지원자C");
+        Applicant 지원자D = 테스트지원자(면접, "지원자D");
+        Favorite 지원자B_즐겨찾기 = 테스트즐겨찾기(지원자B, 종미);
+        Favorite 지원자D_즐겨찾기 = 테스트즐겨찾기(지원자D, 종미);
+
+        testRepository.save(종미, 프로젝트, 면접, 지원자A, 지원자B, 지원자C, 지원자D, 지원자B_즐겨찾기, 지원자D_즐겨찾기);
+
+        // when
+        List<Favorite> 조회결과 = favoriteRepository.findAllByMemberAndApplicantIn(종미, List.of(지원자A, 지원자B, 지원자C));
+
+        // then
+        assertThat(조회결과).hasSize(1)
+                .extracting(Favorite::getApplicant)
+                .contains(지원자B);
+    }
+}

--- a/src/test/java/com/gotcha/server/applicant/service/ApplicantServiceTest.java
+++ b/src/test/java/com/gotcha/server/applicant/service/ApplicantServiceTest.java
@@ -12,6 +12,7 @@ import com.gotcha.server.applicant.domain.KeywordType;
 import com.gotcha.server.applicant.dto.request.GoQuestionPublicRequest;
 import com.gotcha.server.applicant.dto.request.InterviewProceedRequest;
 import com.gotcha.server.applicant.dto.response.ApplicantResponse;
+import com.gotcha.server.applicant.dto.response.ApplicantsResponse;
 import com.gotcha.server.applicant.repository.ApplicantRepository;
 import com.gotcha.server.applicant.repository.FavoriteRepository;
 import com.gotcha.server.auth.dto.request.MemberDetails;
@@ -153,5 +154,27 @@ class ApplicantServiceTest extends IntegrationTest {
         // then
         Optional<Favorite> 즐겨찾기 = favoriteRepository.findByApplicantAndMember(지원자A, 종미);
         assertTrue(즐겨찾기.isEmpty());
+    }
+
+    @Test
+    void 지원자목록_조회시_즐겨찾기_여부_반환하기() {
+        // given
+        Project 테스트프로젝트 = environ.테스트프로젝트_저장하기();
+        Interview 테스트면접 = environ.테스트면접_저장하기(테스트프로젝트, "테스트면접");
+        Applicant 지원자A = environ.테스트지원자_저장하기(테스트면접, "지원자A");
+        Applicant 지원자B = environ.테스트지원자_저장하기(테스트면접, "지원자B");
+        Applicant 지원자C = environ.테스트지원자_저장하기(테스트면접, "지원자C");
+        Applicant 지원자D = environ.테스트지원자_저장하기(테스트면접, "지원자D");
+        Member 종미 = environ.테스트유저_저장하기("종미");
+        environ.테스트즐겨찾기_저장하기(지원자B, 종미);
+        environ.테스트즐겨찾기_저장하기(지원자D, 종미);
+
+        // when
+        List<ApplicantsResponse> 지원자목록 = applicantService.listApplicantsByInterview(테스트면접.getId(), new MemberDetails(종미));
+
+        // then
+        assertThat(지원자목록).hasSize(4)
+                .extracting(ApplicantsResponse::getFavorite)
+                .contains(false, true, false, true);
     }
 }

--- a/src/test/java/com/gotcha/server/common/IntegrationTestEnviron.java
+++ b/src/test/java/com/gotcha/server/common/IntegrationTestEnviron.java
@@ -3,10 +3,12 @@ package com.gotcha.server.common;
 import static com.gotcha.server.common.TestFixture.*;
 
 import com.gotcha.server.applicant.domain.Applicant;
+import com.gotcha.server.applicant.domain.Favorite;
 import com.gotcha.server.applicant.domain.Interviewer;
 import com.gotcha.server.applicant.domain.Keyword;
 import com.gotcha.server.applicant.domain.KeywordType;
 import com.gotcha.server.applicant.repository.ApplicantRepository;
+import com.gotcha.server.applicant.repository.FavoriteRepository;
 import com.gotcha.server.applicant.repository.InterviewerRepository;
 import com.gotcha.server.applicant.repository.KeywordRepository;
 import com.gotcha.server.evaluation.domain.Evaluation;
@@ -36,6 +38,7 @@ public class IntegrationTestEnviron {
     private final IndividualQuestionRepository individualQuestionRepository;
     private final EvaluationRepository evaluationRepository;
     private final CommonQuestionRepository commonQuestionRepository;
+    private final FavoriteRepository favoriteRepository;
 
     public Member 테스트유저_저장하기(String 이름) {
         return memberRepository.save(테스트유저(이름));
@@ -76,5 +79,9 @@ public class IntegrationTestEnviron {
 
     public Evaluation 테스트평가_저장하기(Integer 점수, String 평가내용, IndividualQuestion 질문, Member 면접관) {
         return evaluationRepository.save(테스트평가(점수, 평가내용, 질문, 면접관));
+    }
+
+    public Favorite 테스트즐겨찾기_저장하기(Applicant 지원자, Member 면접관) {
+        return favoriteRepository.save(테스트즐겨찾기(지원자, 면접관));
     }
 }

--- a/src/test/java/com/gotcha/server/common/TestFixture.java
+++ b/src/test/java/com/gotcha/server/common/TestFixture.java
@@ -1,6 +1,7 @@
 package com.gotcha.server.common;
 
 import com.gotcha.server.applicant.domain.Applicant;
+import com.gotcha.server.applicant.domain.Favorite;
 import com.gotcha.server.applicant.domain.Interviewer;
 import com.gotcha.server.applicant.domain.Keyword;
 import com.gotcha.server.applicant.domain.KeywordType;
@@ -80,5 +81,9 @@ public class TestFixture {
                 .member(면접관)
                 .question(질문)
                 .build();
+    }
+
+    public static Favorite 테스트즐겨찾기(Applicant 지원자, Member 면접관) {
+        return new Favorite(면접관, 지원자);
     }
 }


### PR DESCRIPTION
## Check 🌈

- [x] 배포 브랜치에 바로 merge합니다
- [x] merge는 PR 작성자가 합니다

## Description 📒

>추가된 기능
>1. 유저의 email 수정
>2. 지원자 즐겨찾기 기능

## To Reviewer 💬

개별 질문 좋아요도 즐겨찾기랑 비슷한거 같아서 제가 얼른 하는게 좋을 거 같네용.. 정말 많네용..

깜빡하고 아래 같은 쿼리에서 `leftJoin` 대신 `innerJoin` 썼었는데 큰일날 뻔 했네요.. 조심하면 좋을 거 같아서 혹시나해서 공유해요.. 
```java
  jpaQueryFactory
                .select(qApplicant)
                .from(qApplicant)
                .leftJoin(qApplicant.interviewers, qInterviewer) // interviewers 없을 수 있음
                .fetchJoin()
                .leftJoin(qInterviewer.member, qMember)
               // 생략
```
