### PR TITLE
Mongo DB를 사용하여 실시간 질문 수정 서비스 로직 구현

### DIFF
--- a/src/main/java/com/gotcha/server/ServerApplication.java
+++ b/src/main/java/com/gotcha/server/ServerApplication.java
@@ -1,6 +1,7 @@
 package com.gotcha.server;
 
 import com.gotcha.server.mongo.repository.BookRepository;
+import com.gotcha.server.mongo.repository.QuestionMongoRepository;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
@@ -13,8 +14,8 @@ import org.springframework.data.mongodb.repository.config.EnableMongoRepositorie
 @SpringBootApplication
 @EnableJpaRepositories(excludeFilters = @ComponentScan.Filter(
 		type = FilterType.ASSIGNABLE_TYPE,
-		classes = {BookRepository.class}))
-@EnableMongoRepositories(basePackageClasses = {BookRepository.class})
+		classes = {BookRepository.class, QuestionMongoRepository.class}))
+@EnableMongoRepositories(basePackageClasses = {BookRepository.class, QuestionMongoRepository.class})
 public class ServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/gotcha/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/gotcha/server/applicant/service/ApplicantService.java
@@ -28,6 +28,7 @@ import com.gotcha.server.project.domain.Interview;
 import com.gotcha.server.project.repository.InterviewRepository;
 
 import com.gotcha.server.question.domain.CommonQuestion;
+import com.gotcha.server.question.event.QuestionDeterminedEvent;
 import com.gotcha.server.question.repository.CommonQuestionRepository;
 
 import java.io.IOException;
@@ -41,6 +42,7 @@ import io.micrometer.common.lang.Nullable;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -61,6 +63,7 @@ public class ApplicantService {
     private final MemberRepository memberRepository;
     private final CommonQuestionRepository commonQuestionRepository;
     private final FavoriteRepository favoriteRepository;
+    private final ApplicationEventPublisher eventPublisher;
     private final AmazonS3 amazonS3;
     private final MailService mailService;
 
@@ -95,6 +98,7 @@ public class ApplicantService {
         Applicant applicant = applicantRepository.findByIdWithInterviewAndInterviewers(applicantId)
                 .orElseThrow(() -> new AppException(ErrorCode.APPLICANT_NOT_FOUNT));
         applicant.setInterviewStatus(InterviewStatus.IN_PROGRESS);
+        eventPublisher.publishEvent(new QuestionDeterminedEvent(applicant.getId()));
     }
 
     public List<ApplicantsResponse> listApplicantsByInterview(final Long interviewId, final MemberDetails details) {

--- a/src/main/java/com/gotcha/server/mongo/domain/QuestionMongo.java
+++ b/src/main/java/com/gotcha/server/mongo/domain/QuestionMongo.java
@@ -1,0 +1,25 @@
+package com.gotcha.server.mongo.domain;
+
+import java.math.BigInteger;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "questions")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class QuestionMongo {
+    @Id
+    private String id;
+    private Long questionId;
+    private String content;
+    private Integer importance;
+    private Integer questionOrder;
+    private Boolean isCommon;
+    private BigInteger applicantId;
+    private BigInteger writerId;
+}

--- a/src/main/java/com/gotcha/server/mongo/domain/QuestionMongo.java
+++ b/src/main/java/com/gotcha/server/mongo/domain/QuestionMongo.java
@@ -1,8 +1,7 @@
 package com.gotcha.server.mongo.domain;
 
-import java.math.BigInteger;
+import com.gotcha.server.question.domain.Question;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
@@ -10,9 +9,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 
 @Document(collection = "questions")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-@Builder
-public class QuestionMongo {
+public class QuestionMongo implements Question {
     @Id
     private String id;
     private Long questionId;
@@ -20,6 +17,38 @@ public class QuestionMongo {
     private Integer importance;
     private Integer questionOrder;
     private Boolean isCommon;
-    private BigInteger applicantId;
-    private BigInteger writerId;
+    private Long applicantId;
+    private Long writerId;
+    private Boolean asking;
+
+    @Builder
+    public QuestionMongo(
+            final Long questionId, final String content,
+            final Integer importance, final Integer questionOrder,
+            final Boolean isCommon, final Long applicantId, final Long writerId) {
+        this.questionId = questionId;
+        this.content = content;
+        this.importance = importance;
+        this.questionOrder = questionOrder;
+        this.isCommon = isCommon;
+        this.applicantId = applicantId;
+        this.writerId = writerId;
+        this.asking = true;
+    }
+
+    public void updateOrder(final Integer order) {
+        this.questionOrder = order;
+    }
+
+    public void updateImportance(final Integer importance) {
+        this.importance = importance;
+    }
+
+    public void updateContent(final String content) {
+        this.content = content;
+    }
+
+    public void deleteDuringInterview() {
+        this.asking = false;
+    }
 }

--- a/src/main/java/com/gotcha/server/mongo/domain/QuestionMongo.java
+++ b/src/main/java/com/gotcha/server/mongo/domain/QuestionMongo.java
@@ -1,12 +1,15 @@
 package com.gotcha.server.mongo.domain;
 
+import com.gotcha.server.question.domain.IndividualQuestion;
 import com.gotcha.server.question.domain.Question;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+@Getter
 @Document(collection = "questions")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class QuestionMongo implements Question {
@@ -18,21 +21,19 @@ public class QuestionMongo implements Question {
     private Integer questionOrder;
     private Boolean isCommon;
     private Long applicantId;
-    private Long writerId;
     private Boolean asking;
 
     @Builder
     public QuestionMongo(
             final Long questionId, final String content,
             final Integer importance, final Integer questionOrder,
-            final Boolean isCommon, final Long applicantId, final Long writerId) {
+            final Boolean isCommon, final Long applicantId) {
         this.questionId = questionId;
         this.content = content;
         this.importance = importance;
         this.questionOrder = questionOrder;
         this.isCommon = isCommon;
         this.applicantId = applicantId;
-        this.writerId = writerId;
         this.asking = true;
     }
 
@@ -50,5 +51,16 @@ public class QuestionMongo implements Question {
 
     public void deleteDuringInterview() {
         this.asking = false;
+    }
+
+    public static QuestionMongo from(final IndividualQuestion individualQuestion, final Long applicantId) {
+        return QuestionMongo.builder()
+                .questionId(individualQuestion.getId())
+                .content(individualQuestion.getContent())
+                .importance(individualQuestion.getImportance())
+                .questionOrder(individualQuestion.getQuestionOrder())
+                .isCommon(individualQuestion.isCommon())
+                .applicantId(applicantId)
+                .build();
     }
 }

--- a/src/main/java/com/gotcha/server/mongo/domain/QuestionMongo.java
+++ b/src/main/java/com/gotcha/server/mongo/domain/QuestionMongo.java
@@ -63,4 +63,14 @@ public class QuestionMongo implements Question {
                 .applicantId(applicantId)
                 .build();
     }
+
+    public IndividualQuestion updateQuestion(final IndividualQuestion question) {
+        question.updateOrder(questionOrder);
+        question.updateImportance(importance);
+        question.updateContent(content);
+        if(!asking) {
+            question.deleteDuringInterview();
+        }
+        return question;
+    }
 }

--- a/src/main/java/com/gotcha/server/mongo/repository/QuestionMongoRepository.java
+++ b/src/main/java/com/gotcha/server/mongo/repository/QuestionMongoRepository.java
@@ -1,9 +1,11 @@
 package com.gotcha.server.mongo.repository;
 
 import com.gotcha.server.mongo.domain.QuestionMongo;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 public interface QuestionMongoRepository extends MongoRepository<QuestionMongo, String> {
     Optional<QuestionMongo> findByQuestionId(Long questionId);
+    List<QuestionMongo> findAllByApplicantId(Long applicantId);
 }

--- a/src/main/java/com/gotcha/server/mongo/repository/QuestionMongoRepository.java
+++ b/src/main/java/com/gotcha/server/mongo/repository/QuestionMongoRepository.java
@@ -1,0 +1,9 @@
+package com.gotcha.server.mongo.repository;
+
+import com.gotcha.server.mongo.domain.QuestionMongo;
+import java.math.BigInteger;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface QuestionMongoRepository extends MongoRepository<QuestionMongo, BigInteger> {
+
+}

--- a/src/main/java/com/gotcha/server/mongo/repository/QuestionMongoRepository.java
+++ b/src/main/java/com/gotcha/server/mongo/repository/QuestionMongoRepository.java
@@ -1,9 +1,9 @@
 package com.gotcha.server.mongo.repository;
 
 import com.gotcha.server.mongo.domain.QuestionMongo;
-import java.math.BigInteger;
+import java.util.Optional;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
-public interface QuestionMongoRepository extends MongoRepository<QuestionMongo, BigInteger> {
-
+public interface QuestionMongoRepository extends MongoRepository<QuestionMongo, String> {
+    Optional<QuestionMongo> findByQuestionId(Long questionId);
 }

--- a/src/main/java/com/gotcha/server/question/domain/IndividualQuestion.java
+++ b/src/main/java/com/gotcha/server/question/domain/IndividualQuestion.java
@@ -22,7 +22,7 @@ import static java.lang.Boolean.TRUE;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class IndividualQuestion extends BaseTimeEntity {
+public class IndividualQuestion extends BaseTimeEntity implements Question {
     private static final int MIN_IMPORTANCE = 3;
     private static final int MAX_IMPORTANCE = 5;
 
@@ -112,7 +112,7 @@ public class IndividualQuestion extends BaseTimeEntity {
         }
     }
 
-    public void updateContent(String content) {
+    public void updateContent(final String content) {
         this.content = content;
     }
 

--- a/src/main/java/com/gotcha/server/question/domain/Question.java
+++ b/src/main/java/com/gotcha/server/question/domain/Question.java
@@ -1,0 +1,8 @@
+package com.gotcha.server.question.domain;
+
+public interface Question {
+    void updateOrder(final Integer order);
+    void updateImportance(final Integer importance);
+    void updateContent(final String content);
+    void deleteDuringInterview();
+}

--- a/src/main/java/com/gotcha/server/question/event/QuestionDeterminedEvent.java
+++ b/src/main/java/com/gotcha/server/question/event/QuestionDeterminedEvent.java
@@ -1,0 +1,5 @@
+package com.gotcha.server.question.event;
+
+public record QuestionDeterminedEvent(Long applicantId) {
+
+}

--- a/src/main/java/com/gotcha/server/question/event/QuestionPreparedEvent.java
+++ b/src/main/java/com/gotcha/server/question/event/QuestionPreparedEvent.java
@@ -1,0 +1,8 @@
+package com.gotcha.server.question.event;
+
+import com.gotcha.server.question.domain.IndividualQuestion;
+import java.util.List;
+
+public record QuestionPreparedEvent(List<IndividualQuestion> individualQuestions, Long applicantId) {
+
+}

--- a/src/main/java/com/gotcha/server/question/event/QuestionUpdatedEvent.java
+++ b/src/main/java/com/gotcha/server/question/event/QuestionUpdatedEvent.java
@@ -1,0 +1,8 @@
+package com.gotcha.server.question.event;
+
+import com.gotcha.server.mongo.domain.QuestionMongo;
+import java.util.List;
+
+public record QuestionUpdatedEvent(List<QuestionMongo> mongoQuestions) {
+
+}

--- a/src/main/java/com/gotcha/server/question/repository/IndividualQuestionRepository.java
+++ b/src/main/java/com/gotcha/server/question/repository/IndividualQuestionRepository.java
@@ -11,4 +11,6 @@ public interface IndividualQuestionRepository extends JpaRepository<IndividualQu
             + "JOIN fetch q.applicant "
             + "WHERE q.id IN :ids")
     List<IndividualQuestion> findAllWithApplicantByIdIn(@Param(value = "ids") List<Long> ids);
+
+    List<IndividualQuestion> findAllByIdIn(List<Long> ids);
 }

--- a/src/main/java/com/gotcha/server/question/service/QuestionService.java
+++ b/src/main/java/com/gotcha/server/question/service/QuestionService.java
@@ -21,6 +21,7 @@ import com.gotcha.server.question.domain.IndividualQuestion;
 import com.gotcha.server.question.dto.request.CommonQuestionsRequest;
 import com.gotcha.server.question.dto.response.InterviewQuestionResponse;
 import com.gotcha.server.question.dto.response.PreparatoryQuestionResponse;
+import com.gotcha.server.question.event.QuestionPreparedEvent;
 import com.gotcha.server.question.repository.CommonQuestionRepository;
 import com.gotcha.server.question.repository.IndividualQuestionRepository;
 import com.gotcha.server.question.repository.LikeRepository;
@@ -30,6 +31,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,6 +44,7 @@ public class QuestionService {
     private final InterviewRepository interviewRepository;
     private final ApplicantRepository applicantRepository;
     private final LikeRepository likeRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public void createCommonQuestions(final CommonQuestionsRequest request) {
@@ -133,6 +136,7 @@ public class QuestionService {
         Applicant applicant = applicantRepository.findById(applicantId)
                 .orElseThrow(() -> new AppException(ErrorCode.APPLICANT_NOT_FOUNT));
         List<IndividualQuestion> individualQuestions = individualQuestionRepository.findAllDuringInterview(applicant);
+        eventPublisher.publishEvent(new QuestionPreparedEvent(individualQuestions, applicantId));
         return individualQuestions.stream().map(PreparatoryQuestionResponse::from).toList();
     }
 

--- a/src/main/java/com/gotcha/server/question/service/QuestionUpdateType.java
+++ b/src/main/java/com/gotcha/server/question/service/QuestionUpdateType.java
@@ -1,6 +1,6 @@
 package com.gotcha.server.question.service;
 
-import com.gotcha.server.question.domain.IndividualQuestion;
+import com.gotcha.server.question.domain.Question;
 import java.util.function.BiConsumer;
 
 public enum QuestionUpdateType {
@@ -9,13 +9,13 @@ public enum QuestionUpdateType {
     CONTENT((question, value) -> question.updateContent((String) value)),
     DELETE((question, value) -> question.deleteDuringInterview());
 
-    private BiConsumer<IndividualQuestion, Object> expression;
+    private BiConsumer<Question, Object> expression;
 
-    QuestionUpdateType(final BiConsumer<IndividualQuestion, Object> expression) {
+    QuestionUpdateType(final BiConsumer<Question, Object> expression) {
         this.expression = expression;
     }
 
-    public void update(final IndividualQuestion question, final Object value) {
+    public void update(final Question question, final Object value) {
         expression.accept(question, value);
     }
 }

--- a/src/main/java/com/gotcha/server/question/service/StompQuestionService.java
+++ b/src/main/java/com/gotcha/server/question/service/StompQuestionService.java
@@ -24,7 +24,6 @@ public class StompQuestionService {
     private final QuestionMongoRepository questionMongoRepository;
     private final ApplicationEventPublisher eventPublisher;
 
-    @Transactional
     @EventListener(QuestionPreparedEvent.class)
     public void migrateQuestions(final QuestionPreparedEvent event) {
         Long applicantId = event.applicantId();
@@ -34,12 +33,12 @@ public class StompQuestionService {
         questionMongoRepository.saveAll(mongoQuestions);
     }
 
-    @Transactional
     public void updateQuestion(final Long questionId, final QuestionUpdateMessage message) {
         QuestionMongo question = questionMongoRepository.findByQuestionId(questionId)
                 .orElseThrow(() -> new AppException(ErrorCode.QUESTION_NOT_FOUNT));
         QuestionUpdateType updateType = message.type();
         updateType.update(question, message.value());
+        questionMongoRepository.save(question);
     }
 
     @EventListener(QuestionDeterminedEvent.class)

--- a/src/main/java/com/gotcha/server/question/service/StompQuestionService.java
+++ b/src/main/java/com/gotcha/server/question/service/StompQuestionService.java
@@ -1,0 +1,24 @@
+package com.gotcha.server.question.service;
+
+import com.gotcha.server.global.exception.AppException;
+import com.gotcha.server.global.exception.ErrorCode;
+import com.gotcha.server.mongo.domain.QuestionMongo;
+import com.gotcha.server.mongo.repository.QuestionMongoRepository;
+import com.gotcha.server.question.dto.message.QuestionUpdateMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class StompQuestionService {
+    private final QuestionMongoRepository questionMongoRepository;
+
+    @Transactional
+    public void updateQuestion(final Long questionId, final QuestionUpdateMessage message) {
+        QuestionMongo question = questionMongoRepository.findByQuestionId(questionId)
+                .orElseThrow(() -> new AppException(ErrorCode.QUESTION_NOT_FOUNT));
+        QuestionUpdateType updateType = message.type();
+        updateType.update(question, message.value());
+    }
+}

--- a/src/test/java/com/gotcha/server/common/DatabaseCleaner.java
+++ b/src/test/java/com/gotcha/server/common/DatabaseCleaner.java
@@ -4,7 +4,10 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,6 +17,9 @@ public class DatabaseCleaner implements InitializingBean {
 
     @PersistenceContext
     private EntityManager entityManager;
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
 
     @Override
     public void afterPropertiesSet() {
@@ -30,9 +36,17 @@ public class DatabaseCleaner implements InitializingBean {
         entityManager.createNativeQuery("SET foreign_key_checks = 1").executeUpdate();
     }
 
+    private void truncateMongo() {
+        Set<String> collectionNames = mongoTemplate.getCollectionNames();
+        for (String collectionName : collectionNames) {
+            mongoTemplate.dropCollection(collectionName);
+        }
+    }
+
     @Transactional
     public void clear() {
         entityManager.clear();
         truncate();
+        truncateMongo();
     }
 }

--- a/src/test/java/com/gotcha/server/common/IntegrationTestEnviron.java
+++ b/src/test/java/com/gotcha/server/common/IntegrationTestEnviron.java
@@ -15,6 +15,8 @@ import com.gotcha.server.evaluation.domain.Evaluation;
 import com.gotcha.server.evaluation.repository.EvaluationRepository;
 import com.gotcha.server.member.domain.Member;
 import com.gotcha.server.member.repository.MemberRepository;
+import com.gotcha.server.mongo.domain.QuestionMongo;
+import com.gotcha.server.mongo.repository.QuestionMongoRepository;
 import com.gotcha.server.project.domain.Interview;
 import com.gotcha.server.project.domain.Project;
 import com.gotcha.server.project.repository.InterviewRepository;
@@ -25,6 +27,7 @@ import com.gotcha.server.question.domain.Likes;
 import com.gotcha.server.question.repository.CommonQuestionRepository;
 import com.gotcha.server.question.repository.IndividualQuestionRepository;
 import com.gotcha.server.question.repository.LikeRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -42,6 +45,7 @@ public class IntegrationTestEnviron {
     private final CommonQuestionRepository commonQuestionRepository;
     private final FavoriteRepository favoriteRepository;
     private final LikeRepository likeRepository;
+    private final QuestionMongoRepository questionMongoRepository;
 
     public Member 테스트유저_저장하기(String 이름) {
         return memberRepository.save(테스트유저(이름));
@@ -90,5 +94,18 @@ public class IntegrationTestEnviron {
 
     public Likes 테스트좋아요_저장하기(IndividualQuestion 질문, Member 면접관) {
         return likeRepository.save(테스트좋아요(질문, 면접관));
+    }
+
+    public QuestionMongo 테스트몽고DB질문_저장하기(IndividualQuestion 질문, Long 지원자ID) {
+        return questionMongoRepository.save(테스트몽고DB질문(질문, 지원자ID));
+    }
+
+    public QuestionMongo 테스트몽고DB질문_수정하기(QuestionMongo 질문, String 수정내용) {
+        질문.updateContent(수정내용);
+        return questionMongoRepository.save(질문);
+    }
+
+    public List<QuestionMongo> 테스트몽고DB질문_조회하기() {
+        return questionMongoRepository.findAll();
     }
 }

--- a/src/test/java/com/gotcha/server/common/TestFixture.java
+++ b/src/test/java/com/gotcha/server/common/TestFixture.java
@@ -7,6 +7,7 @@ import com.gotcha.server.applicant.domain.Keyword;
 import com.gotcha.server.applicant.domain.KeywordType;
 import com.gotcha.server.evaluation.domain.Evaluation;
 import com.gotcha.server.member.domain.Member;
+import com.gotcha.server.mongo.domain.QuestionMongo;
 import com.gotcha.server.project.domain.Collaborator;
 import com.gotcha.server.project.domain.Interview;
 import com.gotcha.server.project.domain.Project;
@@ -90,5 +91,9 @@ public class TestFixture {
 
     public static Likes 테스트좋아요(IndividualQuestion 질문, Member 면접관) {
         return new Likes(면접관, 질문);
+    }
+
+    public static QuestionMongo 테스트몽고DB질문(IndividualQuestion 질문, Long 지원자ID) {
+        return QuestionMongo.from(질문, 지원자ID);
     }
 }

--- a/src/test/java/com/gotcha/server/question/service/StompQuestionServiceTest.java
+++ b/src/test/java/com/gotcha/server/question/service/StompQuestionServiceTest.java
@@ -1,0 +1,45 @@
+package com.gotcha.server.question.service;
+
+import static com.gotcha.server.common.TestFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gotcha.server.applicant.domain.Applicant;
+import com.gotcha.server.common.IntegrationTest;
+import com.gotcha.server.mongo.domain.QuestionMongo;
+import com.gotcha.server.mongo.repository.QuestionMongoRepository;
+import com.gotcha.server.project.domain.Interview;
+import com.gotcha.server.project.domain.Project;
+import com.gotcha.server.question.domain.IndividualQuestion;
+import com.gotcha.server.question.event.QuestionPreparedEvent;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class StompQuestionServiceTest extends IntegrationTest {
+    @Autowired
+    private StompQuestionService stompQuestionService;
+
+    @Autowired
+    private QuestionMongoRepository questionMongoRepository;
+
+    @Test
+    void MongDB로_질문목록_이전하기() {
+        // given
+        Project 조회할프로젝트 = 테스트프로젝트("테스트프로젝트");
+        Interview 조회할면접 = 테스트면접(조회할프로젝트, "테스트면접1");
+        Applicant 지원자A = 테스트지원자(조회할면접, "지원자A");
+        List<IndividualQuestion> 질문목록 = List.of(
+                테스트개별질문(지원자A, "내용1", 1, true, 5, null),
+                테스트개별질문(지원자A, "내용2", 2, true, 5, null));
+
+        // when
+        QuestionPreparedEvent 이벤트 = new QuestionPreparedEvent(질문목록, 지원자A.getId());
+        stompQuestionService.migrateQuestions(이벤트);
+
+        // then
+        List<QuestionMongo> 이전된_질문목록 = questionMongoRepository.findAll();
+        assertThat(이전된_질문목록).hasSize(2)
+                .extracting(QuestionMongo::getContent)
+                .contains("내용1", "내용2");
+    }
+}


### PR DESCRIPTION
## Check 🌈

- [ ] 배포 브랜치에 바로 merge합니다
- [ ] merge는 PR 작성자가 합니다

## Description 📒

>- 한꺼번에 데이터를 업데이트해야 하는데, batch 사용하는 걸 고려해야 할 것 같습니다.
>- 트랜잭션 격리시키기 위해 event 도입했는데, 지금 applicant 패키지에 다른 도메인들이 많이 의존하고 있어서 event로 분리하는 리팩토링 진행하면 좋을 것 같습니다.
>- 현재 몽고DB 설정으로는 트랜잭션을 사용하지 않는데, 이대로 트랜잭션 사용 안해도 괜찮을지?? 