### PR TITLE
지원자 관련 서비스 로직 리팩토링

### DIFF
--- a/src/main/java/com/gotcha/server/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/gotcha/server/applicant/controller/ApplicantController.java
@@ -31,7 +31,7 @@ public class ApplicantController {
     public ResponseEntity<InterviewProceedResponse> proceedToInterview(
             @RequestBody final InterviewProceedRequest request,
             @AuthenticationPrincipal final MemberDetails details) {
-        return ResponseEntity.ok(applicantService.proceedToInterview(request, details));
+        return ResponseEntity.ok(applicantService.prepareInterview(request, details));
     }
 
     @GetMapping

--- a/src/main/java/com/gotcha/server/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/gotcha/server/applicant/controller/ApplicantController.java
@@ -12,7 +12,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import java.io.IOException;
 import java.util.List;
 
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -28,7 +27,7 @@ public class ApplicantController {
 
     @PostMapping("/interview-ready")
     @Operation(description = "로그인 유저(면접관)가 면접 준비 완료를 요청한다. 모든 면접관이 준비 완료되었다면 지원자의 면접 단계가 바뀐다.")
-    public ResponseEntity<InterviewProceedResponse> proceedToInterview(
+    public ResponseEntity<PreparedInterviewersResponse> proceedToInterview(
             @RequestBody final InterviewProceedRequest request,
             @AuthenticationPrincipal final MemberDetails details) {
         return ResponseEntity.ok(applicantService.prepareInterview(request, details));

--- a/src/main/java/com/gotcha/server/applicant/domain/Applicant.java
+++ b/src/main/java/com/gotcha/server/applicant/domain/Applicant.java
@@ -68,7 +68,9 @@ public class Applicant extends BaseTimeEntity implements Comparable<Applicant> {
     private String portfolio;
 
     @Builder
-    public Applicant(Interview interview, String email, LocalDate date, String name, Integer age, String education, String phoneNumber, String position, String path, String resumeLink, String portfolio) {
+    public Applicant(final Interview interview, final String email, final LocalDate date,
+            final String name, final Integer age, final String education, final String phoneNumber,
+            final String position, final String path, final String resumeLink, final String portfolio) {
         this.interview = interview;
         this.email = email;
         this.date = date;
@@ -128,7 +130,6 @@ public class Applicant extends BaseTimeEntity implements Comparable<Applicant> {
 
     public void removeInterviewer(final Interviewer interviewer) {
         interviewers.remove(interviewer);
-        interviewer.setApplicant(null);
     }
 
     public void addQuestion(final IndividualQuestion question) {
@@ -138,7 +139,6 @@ public class Applicant extends BaseTimeEntity implements Comparable<Applicant> {
 
     public void removeQuestion(final IndividualQuestion question) {
         questions.remove(question);
-        question.setApplicant(null);
     }
 
     public void addKeyword(Keyword keyword) {
@@ -148,11 +148,6 @@ public class Applicant extends BaseTimeEntity implements Comparable<Applicant> {
 
     public void removeKeyword(Keyword keyword) {
         keywords.remove(keyword);
-        keyword.setApplicant(null);
-    }
-
-    public void setDate(LocalDate date) {
-        this.date = date;
     }
 
     public PreparedInterviewersResponse getPreparedInterviewerInfo() {

--- a/src/main/java/com/gotcha/server/applicant/domain/Applicant.java
+++ b/src/main/java/com/gotcha/server/applicant/domain/Applicant.java
@@ -1,5 +1,6 @@
 package com.gotcha.server.applicant.domain;
 
+import com.gotcha.server.applicant.dto.response.PreparedInterviewersResponse;
 import com.gotcha.server.global.exception.AppException;
 import com.gotcha.server.global.exception.ErrorCode;
 import com.gotcha.server.member.domain.Member;
@@ -110,9 +111,10 @@ public class Applicant extends BaseTimeEntity implements Comparable<Applicant> {
         this.interviewStatus = status;
     }
 
-    public Interviewer pickInterviewer(final Member member) {
-        return interviewers.stream().filter(i -> i.hasPermission(member))
+    public void setInterviewerPrepared(final Member member) {
+         Interviewer interviewer = interviewers.stream().filter(i -> i.hasPermission(member))
                 .findAny().orElseThrow(() -> new AppException(ErrorCode.UNAUTHORIZED_INTERVIEWER));
+         interviewer.setPrepared();
     }
 
     public void changeQuestionPublicType(boolean agree) {
@@ -151,6 +153,12 @@ public class Applicant extends BaseTimeEntity implements Comparable<Applicant> {
 
     public void setDate(LocalDate date) {
         this.date = date;
+    }
+
+    public PreparedInterviewersResponse getPreparedInterviewerInfo() {
+        long interviewerCount = interviewers.size();
+        long preparedInterviewerCount = interviewers.stream().filter(Interviewer::isPrepared).count();
+        return new PreparedInterviewersResponse(interviewerCount, preparedInterviewerCount);
     }
 
     @Override

--- a/src/main/java/com/gotcha/server/applicant/dto/response/InterviewProceedResponse.java
+++ b/src/main/java/com/gotcha/server/applicant/dto/response/InterviewProceedResponse.java
@@ -1,5 +1,0 @@
-package com.gotcha.server.applicant.dto.response;
-
-public record InterviewProceedResponse(long interviewerCount, long preparedInterviewerCount) {
-
-}

--- a/src/main/java/com/gotcha/server/applicant/dto/response/PreparedInterviewersResponse.java
+++ b/src/main/java/com/gotcha/server/applicant/dto/response/PreparedInterviewersResponse.java
@@ -1,0 +1,5 @@
+package com.gotcha.server.applicant.dto.response;
+
+public record PreparedInterviewersResponse(long interviewerCount, long preparedInterviewerCount) {
+
+}

--- a/src/main/java/com/gotcha/server/applicant/event/InterviewStartedEvent.java
+++ b/src/main/java/com/gotcha/server/applicant/event/InterviewStartedEvent.java
@@ -1,0 +1,7 @@
+package com.gotcha.server.applicant.event;
+
+import com.gotcha.server.applicant.domain.Applicant;
+
+public record InterviewStartedEvent(Applicant applicant) {
+
+}

--- a/src/main/java/com/gotcha/server/applicant/event/OutcomePublishedEvent.java
+++ b/src/main/java/com/gotcha/server/applicant/event/OutcomePublishedEvent.java
@@ -1,0 +1,7 @@
+package com.gotcha.server.applicant.event;
+
+import com.gotcha.server.applicant.domain.Applicant;
+
+public record OutcomePublishedEvent(Applicant applicant, String projectName, String interviewName, String positionName) {
+
+}

--- a/src/main/java/com/gotcha/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/gotcha/server/applicant/service/ApplicantService.java
@@ -18,18 +18,15 @@ import com.gotcha.server.evaluation.dto.response.OneLinerResponse;
 import com.gotcha.server.evaluation.repository.OneLinerRepository;
 import com.gotcha.server.global.exception.AppException;
 import com.gotcha.server.global.exception.ErrorCode;
-import com.gotcha.server.mail.service.MailService;
+import com.gotcha.server.external.service.MailService;
 import com.gotcha.server.member.domain.Member;
 import com.gotcha.server.member.repository.MemberRepository;
 import com.gotcha.server.mongo.domain.ApplicantMongo;
 import com.gotcha.server.mongo.repository.ApplicantMongoRepository;
-import com.gotcha.server.mongo.repository.BookRepository;
 import com.gotcha.server.project.domain.Interview;
 import com.gotcha.server.project.repository.InterviewRepository;
 
-import com.gotcha.server.question.domain.CommonQuestion;
 import com.gotcha.server.question.event.QuestionDeterminedEvent;
-import com.gotcha.server.question.repository.CommonQuestionRepository;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/com/gotcha/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/gotcha/server/applicant/service/ApplicantService.java
@@ -89,7 +89,7 @@ public class ApplicantService {
         return ApplicantsResponse.generateList(applicantsWithKeywords, favoritesCheck);
     }
 
-    public Map<Applicant, Boolean> checkFavorites(final List<Applicant> applicants, final Member member) {
+    private Map<Applicant, Boolean> checkFavorites(final List<Applicant> applicants, final Member member) {
         List<Applicant> favorites = favoriteRepository.findAllByMemberAndApplicantIn(member, applicants)
                 .stream().map(Favorite::getApplicant).toList();
         return applicants.stream()
@@ -133,6 +133,7 @@ public class ApplicantService {
         applicant.changeQuestionPublicType(request.agree());
     }
 
+    @Transactional
     public void sendPassEmail(final PassEmailSendRequest request) {
         Interview interview = interviewRepository.findById(request.interviewId())
                 .orElseThrow(() -> new AppException(ErrorCode.INTERVIEW_NOT_FOUNT));

--- a/src/main/java/com/gotcha/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/gotcha/server/applicant/service/ApplicantService.java
@@ -71,7 +71,7 @@ public class ApplicantService {
     private String bucket;
 
     @Transactional
-    public InterviewProceedResponse proceedToInterview(final InterviewProceedRequest request, final MemberDetails details) {
+    public InterviewProceedResponse prepareInterview(final InterviewProceedRequest request, final MemberDetails details) {
         Applicant applicant = applicantRepository.findByIdWithInterviewAndInterviewers(request.applicantId())
                 .orElseThrow(() -> new AppException(ErrorCode.APPLICANT_NOT_FOUNT));
         Interviewer interviewer = applicant.pickInterviewer(details.member());

--- a/src/main/java/com/gotcha/server/external/config/EmailConfig.java
+++ b/src/main/java/com/gotcha/server/external/config/EmailConfig.java
@@ -1,4 +1,4 @@
-package com.gotcha.server.mail.config;
+package com.gotcha.server.external.config;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/gotcha/server/external/config/S3Config.java
+++ b/src/main/java/com/gotcha/server/external/config/S3Config.java
@@ -1,4 +1,4 @@
-package com.gotcha.server.global.config;
+package com.gotcha.server.external.config;
 
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;

--- a/src/main/java/com/gotcha/server/external/service/MailService.java
+++ b/src/main/java/com/gotcha/server/external/service/MailService.java
@@ -1,4 +1,4 @@
-package com.gotcha.server.mail.service;
+package com.gotcha.server.external.service;
 
 import com.gotcha.server.global.exception.AppException;
 import com.gotcha.server.global.exception.ErrorCode;
@@ -7,7 +7,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service

--- a/src/main/java/com/gotcha/server/external/service/MailService.java
+++ b/src/main/java/com/gotcha/server/external/service/MailService.java
@@ -1,12 +1,17 @@
 package com.gotcha.server.external.service;
 
+import com.gotcha.server.applicant.domain.Applicant;
+import com.gotcha.server.applicant.event.OutcomePublishedEvent;
 import com.gotcha.server.global.exception.AppException;
 import com.gotcha.server.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Slf4j
 @Service
@@ -36,5 +41,18 @@ public class MailService {
         message.setText(text);
 
         return message;
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void sendOutcomeEmail(final OutcomePublishedEvent event) {
+        Applicant applicant = event.applicant();
+        String projectName = event.projectName();
+        String interviewName = event.interviewName();
+        String positionName = event.positionName();
+
+        sendEmail(
+                applicant.getEmail(),
+                String.format("%s님의 %s %s %s 면접 지원 결과 내용입니다.", applicant.getName(), projectName, interviewName, positionName),
+                applicant.getOutcome().createPassEmailMessage(applicant.getName(), projectName, interviewName, positionName));
     }
 }

--- a/src/main/java/com/gotcha/server/external/service/S3Service.java
+++ b/src/main/java/com/gotcha/server/external/service/S3Service.java
@@ -1,0 +1,49 @@
+package com.gotcha.server.external.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import io.micrometer.common.lang.Nullable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+public class S3Service {
+    private final String bucket;
+    private final AmazonS3 amazonS3;
+
+    public S3Service(final AmazonS3 amazonS3, @Value("${cloud.aws.s3.bucket}") final String bucket) {
+        this.bucket = bucket;
+        this.amazonS3 = amazonS3;
+    }
+
+    public String saveUploadFile(@Nullable MultipartFile multipartFile) throws IOException {
+        if (multipartFile != null) {
+            ObjectMetadata objectMetadata = new ObjectMetadata();
+            objectMetadata.setContentType(multipartFile.getContentType());
+            objectMetadata.setContentLength(multipartFile.getSize());
+
+            String originalFilename = multipartFile.getOriginalFilename();
+            int index = Objects.requireNonNull(originalFilename).lastIndexOf(".");
+            String ext = originalFilename.substring(index + 1);
+
+            String storeFileName = UUID.randomUUID() + "." + ext;
+            String key = "upload/" + storeFileName;
+
+            try (InputStream inputStream = multipartFile.getInputStream()) {
+                amazonS3.putObject(new PutObjectRequest(bucket, key, inputStream, objectMetadata)
+                        .withCannedAcl(CannedAccessControlList.PublicRead));
+            }
+
+            return amazonS3.getUrl(bucket, key).toString();
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/gotcha/server/mail/service/MailService.java
+++ b/src/main/java/com/gotcha/server/mail/service/MailService.java
@@ -11,7 +11,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class MailService {
 

--- a/src/main/java/com/gotcha/server/project/service/InterviewService.java
+++ b/src/main/java/com/gotcha/server/project/service/InterviewService.java
@@ -2,7 +2,7 @@ package com.gotcha.server.project.service;
 
 import com.gotcha.server.global.exception.AppException;
 import com.gotcha.server.global.exception.ErrorCode;
-import com.gotcha.server.mail.service.MailService;
+import com.gotcha.server.external.service.MailService;
 import com.gotcha.server.member.domain.Member;
 import com.gotcha.server.member.repository.MemberRepository;
 import com.gotcha.server.project.domain.*;

--- a/src/main/java/com/gotcha/server/project/service/ProjectService.java
+++ b/src/main/java/com/gotcha/server/project/service/ProjectService.java
@@ -2,7 +2,7 @@ package com.gotcha.server.project.service;
 
 import com.gotcha.server.global.exception.AppException;
 import com.gotcha.server.global.exception.ErrorCode;
-import com.gotcha.server.mail.service.MailService;
+import com.gotcha.server.external.service.MailService;
 import com.gotcha.server.member.domain.Member;
 import com.gotcha.server.member.repository.MemberRepository;
 import com.gotcha.server.project.domain.*;

--- a/src/test/java/com/gotcha/server/applicant/repository/ApplicantRepositoryTest.java
+++ b/src/test/java/com/gotcha/server/applicant/repository/ApplicantRepositoryTest.java
@@ -11,6 +11,7 @@ import com.gotcha.server.common.RepositoryTest;
 import com.gotcha.server.member.domain.Member;
 import com.gotcha.server.project.domain.Interview;
 import com.gotcha.server.project.domain.Project;
+import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,10 +30,10 @@ class ApplicantRepositoryTest extends RepositoryTest {
         Project 조회할프로젝트 = 테스트프로젝트("테스트프로젝트");
         Interview 조회할면접 = 테스트면접(조회할프로젝트, "테스트면접1");
         Interview 다른면접 = 테스트면접(조회할프로젝트, "테스트면접2");
-        Applicant 지원자A = 테스트지원자(조회할면접, "지원자A");
-        Applicant 지원자B = 테스트지원자(조회할면접, "지원자B");
-        Applicant 지원자C = 테스트지원자(조회할면접, "지원자C");
-        Applicant 지원자D = 테스트지원자(다른면접, "지원자D");
+        Applicant 지원자A = 테스트지원자(조회할면접, "지원자A", LocalDate.now());
+        Applicant 지원자B = 테스트지원자(조회할면접, "지원자B", LocalDate.now());
+        Applicant 지원자C = 테스트지원자(조회할면접, "지원자C", LocalDate.now());
+        Applicant 지원자D = 테스트지원자(다른면접, "지원자D", LocalDate.now());
         Interviewer 종미면접관_지원자A = 테스트면접관(지원자A, 종미);
         Interviewer 종미면접관_지원자B = 테스트면접관(지원자B, 종미);
         Interviewer 종미면접관_지원자C = 테스트면접관(지원자C, 종미);
@@ -69,7 +70,7 @@ class ApplicantRepositoryTest extends RepositoryTest {
         Interview 조회할면접 = 테스트면접(조회할프로젝트, "테스트면접1");
         Applicant 합격지원자A = 평가된_지원자_생성하기(조회할면접, "지원자A", Outcome.PASS);
         Applicant 합격지원자B = 평가된_지원자_생성하기(조회할면접, "지원자B", Outcome.PASS);
-        Applicant 미평가지원자 = 테스트지원자(조회할면접, "지원자C");
+        Applicant 미평가지원자 = 테스트지원자(조회할면접, "지원자C", LocalDate.now());
         Applicant 불합격지원자 = 평가된_지원자_생성하기(조회할면접, "지원자D", Outcome.FAIL);
         testRepository.save(조회할프로젝트, 조회할면접, 합격지원자A, 합격지원자B, 미평가지원자, 불합격지원자);
 
@@ -81,7 +82,7 @@ class ApplicantRepositoryTest extends RepositoryTest {
     }
 
     private Applicant 평가된_지원자_생성하기(Interview 면접, String 이름, Outcome 결과) {
-        Applicant 지원자 = 테스트지원자(면접, 이름);
+        Applicant 지원자 = 테스트지원자(면접, 이름, LocalDate.now());
         지원자.setInterviewStatus(InterviewStatus.COMPLETION);
         지원자.updateOutCome(결과);
         return 지원자;
@@ -96,12 +97,12 @@ class ApplicantRepositoryTest extends RepositoryTest {
         Project 조회할프로젝트 = 테스트프로젝트("테스트프로젝트");
         Interview 조회할면접 = 테스트면접(조회할프로젝트, "테스트면접1");
         Interview 다른면접 = 테스트면접(조회할프로젝트, "테스트면접2");
-        Applicant 지원자A = 테스트지원자(조회할면접, "지원자A");
+        Applicant 지원자A = 테스트지원자(조회할면접, "지원자A", LocalDate.now());
         지원자A.setInterviewStatus(InterviewStatus.COMPLETION);
-        Applicant 지원자B = 테스트지원자(조회할면접, "지원자B");
+        Applicant 지원자B = 테스트지원자(조회할면접, "지원자B", LocalDate.now());
         지원자B.setInterviewStatus(InterviewStatus.COMPLETION);
-        Applicant 지원자C = 테스트지원자(조회할면접, "지원자C");
-        Applicant 지원자D = 테스트지원자(다른면접, "지원자D");
+        Applicant 지원자C = 테스트지원자(조회할면접, "지원자C", LocalDate.now());
+        Applicant 지원자D = 테스트지원자(다른면접, "지원자D", LocalDate.now());
 
         testRepository.save(
                 종미, 윤정,

--- a/src/test/java/com/gotcha/server/applicant/repository/FavoriteRepositoryTest.java
+++ b/src/test/java/com/gotcha/server/applicant/repository/FavoriteRepositoryTest.java
@@ -9,6 +9,7 @@ import com.gotcha.server.common.RepositoryTest;
 import com.gotcha.server.member.domain.Member;
 import com.gotcha.server.project.domain.Interview;
 import com.gotcha.server.project.domain.Project;
+import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,10 +26,10 @@ class FavoriteRepositoryTest extends RepositoryTest {
         Member 종미 = 테스트유저("종미");
         Project 프로젝트 = 테스트프로젝트("테스트프로젝트");
         Interview 면접 = 테스트면접(프로젝트, "테스트면접");
-        Applicant 지원자A = 테스트지원자(면접, "지원자A");
-        Applicant 지원자B = 테스트지원자(면접, "지원자B");
-        Applicant 지원자C = 테스트지원자(면접, "지원자C");
-        Applicant 지원자D = 테스트지원자(면접, "지원자D");
+        Applicant 지원자A = 테스트지원자(면접, "지원자A", LocalDate.now());
+        Applicant 지원자B = 테스트지원자(면접, "지원자B", LocalDate.now());
+        Applicant 지원자C = 테스트지원자(면접, "지원자C", LocalDate.now());
+        Applicant 지원자D = 테스트지원자(면접, "지원자D", LocalDate.now());
         Favorite 지원자B_즐겨찾기 = 테스트즐겨찾기(지원자B, 종미);
         Favorite 지원자D_즐겨찾기 = 테스트즐겨찾기(지원자D, 종미);
 

--- a/src/test/java/com/gotcha/server/applicant/repository/InterviewerRepositoryTest.java
+++ b/src/test/java/com/gotcha/server/applicant/repository/InterviewerRepositoryTest.java
@@ -1,17 +1,14 @@
 package com.gotcha.server.applicant.repository;
 
 import static com.gotcha.server.common.TestFixture.*;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.gotcha.server.applicant.domain.Applicant;
-import com.gotcha.server.applicant.domain.Interviewer;
 import com.gotcha.server.common.RepositoryTest;
 import com.gotcha.server.member.domain.Member;
 import com.gotcha.server.project.domain.Interview;
 import com.gotcha.server.project.domain.Project;
 import java.time.LocalDate;
-import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,12 +27,9 @@ class InterviewerRepositoryTest extends RepositoryTest {
         Interview 테스트면접 = 테스트면접(테스트프로젝트, "테스트면접");
         testRepository.save(종미, 테스트프로젝트, 테스트면접);
 
-        Applicant 지원자A = 테스트지원자(테스트면접, "지원자A");
-        지원자A.setDate(LocalDate.now());
-        Applicant 지원자B = 테스트지원자(테스트면접, "지원자B");
-        지원자B.setDate(LocalDate.now());
-        Applicant 지원자C = 테스트지원자(테스트면접, "지원자C");
-        지원자C.setDate(LocalDate.now().plusDays(3L));
+        Applicant 지원자A = 테스트지원자(테스트면접, "지원자A", LocalDate.now());
+        Applicant 지원자B = 테스트지원자(테스트면접, "지원자B", LocalDate.now());
+        Applicant 지원자C = 테스트지원자(테스트면접, "지원자C", LocalDate.now().plusDays(3L));
         testRepository.save(지원자A, 지원자B, 지원자C);
 
         testRepository.save(테스트면접관(지원자A, 종미), 테스트면접관(지원자B, 종미), 테스트면접관(지원자C, 종미));

--- a/src/test/java/com/gotcha/server/applicant/repository/KeywordRepositoryTest.java
+++ b/src/test/java/com/gotcha/server/applicant/repository/KeywordRepositoryTest.java
@@ -13,6 +13,7 @@ import com.gotcha.server.applicant.dto.response.KeywordResponse;
 import com.gotcha.server.common.RepositoryTest;
 import com.gotcha.server.project.domain.Interview;
 import com.gotcha.server.project.domain.Project;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
@@ -29,8 +30,8 @@ class KeywordRepositoryTest extends RepositoryTest {
         // given
         Project 조회할프로젝트 = 테스트프로젝트("테스트프로젝트");
         Interview 조회할면접 = 테스트면접(조회할프로젝트, "테스트면접1");
-        Applicant 지원자A = 테스트지원자(조회할면접, "지원자A");
-        Applicant 지원자B = 테스트지원자(조회할면접, "지원자B");
+        Applicant 지원자A = 테스트지원자(조회할면접, "지원자A", LocalDate.now());
+        Applicant 지원자B = 테스트지원자(조회할면접, "지원자B", LocalDate.now());
         Keyword 지원자A_성실함 = 테스트키워드(지원자A, "성실함", KeywordType.TRAIT);
         Keyword 지원자A_인턴경험 = 테스트키워드(지원자A, "인턴경험", KeywordType.EXPERIENCE);
         Keyword 지원자A_SQL자격증 = 테스트키워드(지원자A, "SQL자격증", KeywordType.SKILL);

--- a/src/test/java/com/gotcha/server/applicant/service/ApplicantServiceTest.java
+++ b/src/test/java/com/gotcha/server/applicant/service/ApplicantServiceTest.java
@@ -94,7 +94,7 @@ class ApplicantServiceTest extends IntegrationTest {
         MemberDetails 로그인유저 = new MemberDetails(종미);
 
         // when
-        applicantService.proceedToInterview(면접_준비완료_요청, 로그인유저);
+        applicantService.prepareInterview(면접_준비완료_요청, 로그인유저);
 
         // then
         List<IndividualQuestion> 등록된_개별질문들 = individualQuestionRepository.findAllDuringInterview(지원자A);

--- a/src/test/java/com/gotcha/server/common/IntegrationTestEnviron.java
+++ b/src/test/java/com/gotcha/server/common/IntegrationTestEnviron.java
@@ -27,6 +27,7 @@ import com.gotcha.server.question.domain.Likes;
 import com.gotcha.server.question.repository.CommonQuestionRepository;
 import com.gotcha.server.question.repository.IndividualQuestionRepository;
 import com.gotcha.server.question.repository.LikeRepository;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -60,7 +61,7 @@ public class IntegrationTestEnviron {
     }
 
     public Applicant 테스트지원자_저장하기(Interview 면접, String 이름) {
-        return applicantRepository.save(테스트지원자(면접, 이름));
+        return applicantRepository.save(테스트지원자(면접, 이름, LocalDate.now()));
     }
 
     public void 테스트지원자_질문공개하기(Applicant 지원자) {

--- a/src/test/java/com/gotcha/server/common/TestFixture.java
+++ b/src/test/java/com/gotcha/server/common/TestFixture.java
@@ -15,6 +15,7 @@ import com.gotcha.server.project.domain.Subcollaborator;
 import com.gotcha.server.question.domain.CommonQuestion;
 import com.gotcha.server.question.domain.IndividualQuestion;
 import com.gotcha.server.question.domain.Likes;
+import java.time.LocalDate;
 
 public class TestFixture {
     public static Member 테스트유저(String 이름) {
@@ -34,11 +35,12 @@ public class TestFixture {
         return Interview.builder().project(프로젝트).name(면접이름).build();
     }
 
-    public static Applicant 테스트지원자(Interview 면접, String 이름) {
+    public static Applicant 테스트지원자(Interview 면접, String 이름, LocalDate 면접날짜) {
         return Applicant.builder()
                 .name(이름)
                 .interview(면접)
                 .email(String.format("%s email", 이름))
+                .date(면접날짜)
                 .build();
     }
 

--- a/src/test/java/com/gotcha/server/question/service/StompQuestionServiceTest.java
+++ b/src/test/java/com/gotcha/server/question/service/StompQuestionServiceTest.java
@@ -11,6 +11,7 @@ import com.gotcha.server.project.domain.Interview;
 import com.gotcha.server.project.domain.Project;
 import com.gotcha.server.question.domain.IndividualQuestion;
 import com.gotcha.server.question.event.QuestionPreparedEvent;
+import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,7 +28,7 @@ class StompQuestionServiceTest extends IntegrationTest {
         // given
         Project 조회할프로젝트 = 테스트프로젝트("테스트프로젝트");
         Interview 조회할면접 = 테스트면접(조회할프로젝트, "테스트면접1");
-        Applicant 지원자A = 테스트지원자(조회할면접, "지원자A");
+        Applicant 지원자A = 테스트지원자(조회할면접, "지원자A", LocalDate.now());
         List<IndividualQuestion> 질문목록 = List.of(
                 테스트개별질문(지원자A, "내용1", 1, true, 5, null),
                 테스트개별질문(지원자A, "내용2", 2, true, 5, null));


### PR DESCRIPTION
## Check 🌈

- [x] 배포 브랜치에 바로 merge합니다
- [x] merge는 PR 작성자가 합니다

## Description 📒

> 가장 큰 변화는 event 도입입니다. ApplicantService에 집중된 로직을 도메인에 맞게 분리할 수 있고, 합격 결과 이메일 보내는 기능의 경우 (웹어플리케이션/DB와 email 전송 내역이 모두 일치해야 하기 때문에 중요) 해당 서비스 메서드의 트랜잭션이 끝나고 나서 이메일을 보낼 수 있습니다.
