### PR TITLE
AOP 메서드로 인해 Web socket 메세지 전달 안되는 오류 해결

### DIFF
--- a/src/main/java/com/gotcha/server/global/aop/ExecutionTimer.java
+++ b/src/main/java/com/gotcha/server/global/aop/ExecutionTimer.java
@@ -19,12 +19,12 @@ public class ExecutionTimer {
     private void timer(){};
 
     @Around("timer()")
-    public void AssumeExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+    public Object AssumeExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
 
         StopWatch stopWatch = new StopWatch();
 
         stopWatch.start();
-        joinPoint.proceed();
+        Object result = joinPoint.proceed();
         stopWatch.stop();
 
         long totalTimeMillis = stopWatch.getTotalTimeMillis();
@@ -33,5 +33,6 @@ public class ExecutionTimer {
         String methodName = signature.getMethod().getName();
 
         log.info("실행 메서드: {}, 실행시간 = {}ms", methodName, totalTimeMillis);
+        return result;
     }
 }

--- a/src/main/java/com/gotcha/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/gotcha/server/global/exception/ErrorCode.java
@@ -24,7 +24,7 @@ public enum ErrorCode {
     NAME_IS_EMPTY(HttpStatus.BAD_REQUEST, "면접 이름을 입력해주세요."),
     INVALID_EMAIL(HttpStatus.BAD_REQUEST, "유효하지 않은 이메일 주소입니다."),
     INVALID_GOOGLE_EMAIL(HttpStatus.BAD_REQUEST, "구글 이메일 주소가 아닙니다."),
-    INVALID_IMPORTANCE(HttpStatus.BAD_REQUEST, "중요도의 범위는 3~5입니다."),
+    INVALID_IMPORTANCE(HttpStatus.BAD_REQUEST, "중요도의 범위는 1~5입니다."),
     CONTENT_IS_EMPTY(HttpStatus.BAD_REQUEST, "내용을 입력해주세요."),
     MULTIPLE_APPLICANT_EVALUATION(HttpStatus.BAD_REQUEST, "동일하지 않은 지원자에 대한 평가 요청입니다.."),
     DUPLICATE_INTERVIEWER(HttpStatus.BAD_REQUEST, "면접관이 중복되었습니다."),

--- a/src/main/java/com/gotcha/server/question/domain/IndividualQuestion.java
+++ b/src/main/java/com/gotcha/server/question/domain/IndividualQuestion.java
@@ -23,7 +23,7 @@ import static java.lang.Boolean.TRUE;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class IndividualQuestion extends BaseTimeEntity implements Question {
-    private static final int MIN_IMPORTANCE = 3;
+    private static final int MIN_IMPORTANCE = 1;
     private static final int MAX_IMPORTANCE = 5;
 
     @Id


### PR DESCRIPTION
## Check 🌈

- [x] 배포 브랜치에 바로 merge합니다
- [x] merge는 PR 작성자가 합니다

## Description 📒

>웹소켓 메시지는 비동기적으로 처리되기 때문에 aop 메서드에서 반환값을 처리해주어야 합니다. `joinPoint.proceed()`의 반환값을 전달해주는 방식으로 해결했습니다.
